### PR TITLE
Instructions

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -229,6 +229,52 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
         return self.as_dict(include_id) == other.as_dict(include_id)
 
 
+class InstructionBase(ABC):
+    """Base class for Instructions."""
+
+    _action_factory = None
+
+    def as_dict(self):
+        """Return this instruction as a dict."""
+        return vars(self)
+
+    @classmethod
+    def from_dict(cls, instruction_dict):
+        """Return an action instance from attributes in a dictionary."""
+        instruction = cls(None)
+        for attr_name, value in instruction_dict.items():
+            if hasattr(instruction, attr_name):
+                if attr_name == 'actions':
+                    value = [cls._action_factory.from_dict(action_dict)
+                             for action_dict in value]
+                setattr(instruction, attr_name, value)
+        return instruction
+
+
+class InstructionFactoryBase(ABC):
+    """Deal with different instruction implementations."""
+
+    _instruction_class = {
+        'apply_actions': None
+    }
+
+    @classmethod
+    def from_dict(cls, instruction_dict):
+        """Build the proper instruction from a dictionary."""
+        instruction = instruction_dict.get('instruction_type')
+        instruction_class = cls._instruction_class[instruction]
+        return instruction_class.from_dict(instruction_dict) \
+            if instruction_class else None
+
+    @classmethod
+    def from_of_instruction(cls, of_instruction):
+        """Build the proper instruction from a dictionary."""
+        instruction = type(of_instruction)
+        instruction_class = cls._instruction_class[instruction]
+        return instruction_class.from_of_instruction(of_instruction) \
+            if instruction_class else None
+
+
 class ActionBase(ABC):
     """Base class for a flow action."""
 

--- a/v0x04/flow.py
+++ b/v0x04/flow.py
@@ -8,15 +8,28 @@ from pyof.v0x04.common.action import ActionPush as OFActionPush
 from pyof.v0x04.common.action import ActionSetField as OFActionSetField
 from pyof.v0x04.common.action import ActionSetQueue as OFActionSetQueue
 from pyof.v0x04.common.action import ActionType
-from pyof.v0x04.common.flow_instructions import (InstructionApplyAction,
-                                                 InstructionType)
+from pyof.v0x04.common.flow_instructions import \
+    InstructionApplyAction as OFInstructionApplyAction
+from pyof.v0x04.common.flow_instructions import \
+    InstructionClearAction as OFInstructionClearAction
+from pyof.v0x04.common.flow_instructions import \
+    InstructionGotoTable as OFInstructionGotoTable
+from pyof.v0x04.common.flow_instructions import \
+    InstructionMeter as OFInstructionMeter
+from pyof.v0x04.common.flow_instructions import InstructionType
+from pyof.v0x04.common.flow_instructions import \
+    InstructionWriteAction as OFInstructionWriteAction
+from pyof.v0x04.common.flow_instructions import \
+    InstructionWriteMetadata as OFInstructionWriteMetadata
 from pyof.v0x04.common.flow_match import Match as OFMatch
 from pyof.v0x04.common.flow_match import (OxmMatchFields, OxmOfbMatchField,
                                           OxmTLV, VlanId)
 from pyof.v0x04.controller2switch.flow_mod import FlowMod
 
 from napps.kytos.of_core.flow import (ActionBase, ActionFactoryBase, FlowBase,
-                                      FlowStats, MatchBase, PortStats)
+                                      FlowStats, InstructionBase,
+                                      InstructionFactoryBase, MatchBase,
+                                      PortStats)
 from napps.kytos.of_core.v0x04.match_fields import MatchFieldFactory
 
 __all__ = ('ActionOutput', 'ActionSetVlan', 'ActionSetQueue', 'ActionPushVlan',
@@ -185,6 +198,131 @@ class Action(ActionFactoryBase):
         To be used by modules implementing Experimenter Actions.
         """
         cls._action_class[class_name] = new_class
+
+
+class InstructionAction(InstructionBase):
+    """Base class for instruction dealing with actions."""
+
+    _action_factory = Action
+    _instruction_type = None
+    _of_instruction_class = None
+
+    def __init__(self, actions=None):
+        self.instruction_type = self._instruction_type
+        self.actions = actions or []
+
+    def as_dict(self):
+        instruction_dict = {'instruction_type': self.instruction_type}
+        instruction_dict['actions'] = [action.as_dict()
+                                       for action in self.actions]
+        return instruction_dict
+
+    @classmethod
+    def from_of_instruction(cls, of_instruction):
+        """Create high-level Instruction from pyof Instruction."""
+        actions = [Action.from_of_action(of_action)
+                   for of_action in of_instruction.actions]
+        return cls(actions)
+
+    def as_of_instruction(self):
+        """Return a pyof Instruction instance."""
+        of_actions = [action.as_of_action() for action in self.actions]
+        # Disable not-callable error as subclasses will set a class
+        # pylint: disable=not-callable
+        return self._of_instruction_class(of_actions)
+
+
+class InstructionApplyAction(InstructionAction):
+    """Instruct switch to apply the actions."""
+
+    _instruction_type = 'apply_actions'
+    _of_instruction_class = OFInstructionApplyAction
+
+
+class InstructionClearAction(InstructionAction):
+    """Instruct switch to clear the actions."""
+
+    _instruction_type = 'clear_actions'
+    _of_instruction_class = OFInstructionClearAction
+
+
+class InstructionWriteAction(InstructionAction):
+    """Instruct switch to write the actions."""
+
+    _instruction_type = 'write_actions'
+    _of_instruction_class = OFInstructionWriteAction
+
+
+class InstructionGotoTable(InstructionBase):
+    """Instruct the switch to move to another table."""
+
+    def __init__(self, table_id=0):
+        self.instruction_type = 'goto_table'
+        self.table_id = table_id
+
+    @classmethod
+    def from_of_instruction(cls, of_instruction):
+        """Create high-level Instruction from pyof Instruction."""
+        return cls(table_id=of_instruction.table_id.value)
+
+    def as_of_instruction(self):
+        """Return a pyof Instruction instance."""
+        return OFInstructionGotoTable(self.table_id)
+
+
+class InstructionMeter(InstructionBase):
+    """Instruct the switch to apply a meter."""
+
+    def __init__(self, meter_id=0):
+        self.instruction_type = 'meter'
+        self.meter_id = meter_id
+
+    @classmethod
+    def from_of_instruction(cls, of_instruction):
+        """Create high-level Instruction from pyof Instruction."""
+        return cls(meter_id=of_instruction.meter_id.value)
+
+    def as_of_instruction(self):
+        """Return a pyof Instruction instance."""
+        return OFInstructionMeter(self.meter_id)
+
+
+class InstructionWriteMetadata(InstructionBase):
+    """Instruct the switch to write metadata."""
+
+    def __init__(self, metadata=0, metadata_mask=0):
+        self.instruction_type = 'write_metadata'
+        self.metadata = metadata
+        self.metadata_mask = metadata_mask
+
+    @classmethod
+    def from_of_instruction(cls, of_instruction):
+        """Create high-level Instruction from pyof Instruction."""
+        return cls(metadata=of_instruction.metadata.value,
+                   metadata_mask=of_instruction.metadata_mask.value)
+
+    def as_of_instruction(self):
+        """Return a pyof Instruction instance."""
+        return OFInstructionWriteMetadata(self.metadata, self.metadata_mask)
+
+
+class Instruction(InstructionFactoryBase):
+    """An instruction the flow executes."""
+
+    _instruction_class = {
+        'apply_actions': InstructionApplyAction,
+        OFInstructionApplyAction: InstructionApplyAction,
+        'clear_actions': InstructionClearAction,
+        OFInstructionClearAction: InstructionClearAction,
+        'goto_table': InstructionGotoTable,
+        OFInstructionGotoTable: InstructionGotoTable,
+        'meter': InstructionMeter,
+        OFInstructionMeter: InstructionMeter,
+        'write_actions': InstructionWriteAction,
+        OFInstructionWriteAction: InstructionWriteAction,
+        'write_metadata': InstructionWriteMetadata,
+        OFInstructionWriteMetadata: InstructionWriteMetadata
+    }
 
 
 class Flow(FlowBase):


### PR DESCRIPTION
This pull request implements #14.

Description of the change
----------------------------

This PR implements high-level classes for Instructions in OpenFlow 1.3. To do so, the generic flow class does not have an `actions` attribute anymore. The `actions` attribute now only exists in OF 1.0 Flow class. OF 1.3 flow class has a `instructions` attribute, a list
of Instructions.
Base classes for instructions are implemented in base flow file, and the specific classes are implemented in OF 1.3 flow file.
For OF 1.3, `Flow.from_dict` method still support a dict with actions outside instructions, but `Flow.as_dict` always return a dict with actions inside a instruction.

Testing
--------

Some tests had to be changed to reflact the new behavior with `actions`.
New tests were also written.

Release notes
---------------

- Instructions implemented for OF 1.3.
- Action in OF 1.3 flow are always inside a Instruction.