### PR TITLE
Replace kytos with kytos-ng in the requirements file

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
--e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
 -e .[dev]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos/kytos.git#egg=kytos  # via -r requirements/dev.in
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos  # via -r requirements/dev.in
 -e .
--e git+https://github.com/kytos/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in, kytos
+-e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in, kytos
 appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint
 backcall==0.1.0           # via ipython, kytos


### PR DESCRIPTION
This PR fixes #19 

Description of the change
-----------------------------
The requirement files were changes to replate `github.com/kytos` with `github.com/kytos-ng`.

Release notes
---------------
N/A