### PR TITLE
Using switch update_or_create_interface on port_stats event

### DIFF
--- a/tests/unit/v0x04/test_utils.py
+++ b/tests/unit/v0x04/test_utils.py
@@ -48,14 +48,16 @@ class TestUtils(TestCase):
         self.mock_switch.get_interface_by_port_no.side_effect = [MagicMock(),
                                                                  False]
         handle_port_desc(self.mock_controller, self.mock_switch, [mock_port])
-        self.assertEqual(self.mock_switch.update_interface.call_count, 1)
+        call_count = self.mock_switch.update_or_create_interface.call_count
+        self.assertEqual(call_count, 1)
         mock_event_buffer.assert_called()
         self.assertEqual(self.mock_controller.buffers.app.put.call_count, 2)
 
-        self.mock_switch.update_interface.call_count = 0
+        self.mock_switch.update_or_create_interface.call_count = 0
         self.mock_controller.buffers.app.put.call_count = 0
         handle_port_desc(self.mock_controller, self.mock_switch, [mock_port])
-        self.assertEqual(self.mock_switch.update_interface.call_count, 1)
+        call_count = self.mock_switch.update_or_create_interface.call_count
+        self.assertEqual(call_count, 1)
         mock_event_buffer.assert_called()
         self.assertEqual(self.mock_controller.buffers.app.put.call_count, 2)
 

--- a/v0x01/utils.py
+++ b/v0x01/utils.py
@@ -10,7 +10,6 @@ from pyof.v0x01.symmetric.echo_request import EchoRequest
 from pyof.v0x01.symmetric.hello import Hello
 
 from kytos.core import KytosEvent
-from kytos.core.interface import Interface
 from napps.kytos.of_core.utils import emit_message_out
 
 
@@ -91,20 +90,12 @@ def handle_features_reply(controller, event):
                                              connection=connection)
 
     for port in features_reply.ports:
-        interface = switch.get_interface_by_port_no(port.port_no.value)
-        if interface:
-            interface.name = port.name.value
-            interface.address = port.hw_addr.value
-            interface.state = port.state.value
-            interface.features = port.curr
-        else:
-            interface = Interface(name=port.name.value,
-                                  address=port.hw_addr.value,
-                                  port_number=port.port_no.value,
-                                  switch=switch,
-                                  state=port.state.value,
-                                  features=port.curr)
-        switch.update_interface(interface)
+        switch.update_or_create_interface(
+                port.port_no.value,
+                name=port.name.value,
+                address=port.hw_addr.value,
+                state=port.state.value,
+                features=port.curr)
         port_event = KytosEvent(name='kytos/of_core.switch.port.created',
                                 content={
                                     'switch': switch.id,


### PR DESCRIPTION
This PR fixes #17 

Description of the change
-----------------------------
The change enables of_core to use the recently created function `Switch. update_or_create_interface()` instead of creating/updating the Interfaces directly. Using the `Switch.update_or_create_interface()` avoids race-conditions as described in the issue #17.


Release notes
---------------
- The creation/update of Interfaces upon port_stats event now utilizes a locking mechanism to avoid race conditions.