### PR TITLE
Add sanity checks to of_slicer

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,9 @@
 #: Pooling frequency
 STATS_INTERVAL = 60
 
+#: All OpenFlow Versions
+ALL_OPENFLOW_VERSIONS = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
+
 #: Supported Versions
 OPENFLOW_VERSIONS = [0x01, 0x04]
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,6 +26,35 @@ class TestUtils(TestCase):
         self.assertEqual(data, response[0][0])
         self.assertCountEqual(response[1], [])
 
+    def test_of_slicer2(self):
+        """Test of_slicer with insufficient bytes."""
+        data = b'\x04\x00\x00'
+        response = of_slicer(data)
+        self.assertCountEqual(response[0], [])
+        self.assertEqual(response[1], data)
+
+    def test_of_slicer_invalid_data1(self):
+        """Test of_slicer with invalid data: oflen is zero"""
+        data = b'\x04\x00\x00\x00'
+        response = of_slicer(data)
+        self.assertCountEqual(response[0], [])
+        self.assertCountEqual(response[1], [])
+        data = b'\x04\x00\x00\x05\x99\x04\x00\x00\x00'
+        response = of_slicer(data)
+        self.assertEqual(response[0][0], data[:5])
+        self.assertCountEqual(response[1], [])
+
+    def test_of_slicer_invalid_data2(self):
+        """Test of_slicer with invalid data: non openflow"""
+        data = b'\x00\x00\x00\x00'
+        response = of_slicer(data)
+        self.assertCountEqual(response[0], [])
+        self.assertCountEqual(response[1], [])
+        data = b'\x04\x00\x00\x00\x00\x00\x00\x00'
+        response = of_slicer(data)
+        self.assertCountEqual(response[0], [])
+        self.assertCountEqual(response[1], [])
+
     def test_unpack_int(self):
         """Test test_unpack_int."""
         mock_packet = MagicMock()

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ from pyof.foundation.exceptions import PackException, UnpackException
 from pyof.v0x01.common.header import Type as OFPTYPE
 
 from kytos.core import KytosEvent
+from napps.kytos.of_core import settings
 
 
 def of_slicer(remaining_data):
@@ -15,6 +16,12 @@ def of_slicer(remaining_data):
     pkts = []
     while data_len > 3:
         length_field = struct.unpack('!H', remaining_data[2:4])[0]
+        ofver = remaining_data[0]
+        # sanity checks: badly formatted packet
+        if ofver not in settings.OPENFLOW_VERSIONS or length_field == 0:
+            remaining_data = remaining_data[4:]
+            data_len = len(remaining_data)
+            continue
         if data_len >= length_field:
             pkts.append(remaining_data[:length_field])
             remaining_data = remaining_data[length_field:]

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,7 @@ def of_slicer(remaining_data):
         length_field = struct.unpack('!H', remaining_data[2:4])[0]
         ofver = remaining_data[0]
         # sanity checks: badly formatted packet
-        if ofver not in settings.OPENFLOW_VERSIONS or length_field == 0:
+        if ofver not in settings.ALL_OPENFLOW_VERSIONS or length_field == 0:
             remaining_data = remaining_data[4:]
             data_len = len(remaining_data)
             continue


### PR DESCRIPTION
Fixes #23 

### Description of the change

of_core receives data from Kytos Async TCP server as raw_bytes (possibly aggregated) and transform them into individual OpenFlow messages. As part of this routine, `of_slicer()` is the one responsible for splitting the raw data into individual OpenFlow messages (set of bytes) to be later parsed into OpenFlow objects using python-openflow. of_slicer also takes into consideration that the received bytes can represent incomplete messages (due, for instance, to the socket read buffer), and it will return the list of individual packets and the remaining data. The slicing process does not validated some situations, which can lead to inconsistent messages, infinity loop at the server and memory exhaustion.

This PR will add some sanity checks to the slicing process, to avoid those errors.

### Release notes

- Added sanity checks to of_slicer() to prevent against server's resource exhaustion when receiving badly formatted OpenFlow packets.