### PR TITLE
Refactor handle_raw_in to avoid data loss under high usage scenarios

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,10 @@
 #: Pooling frequency
 STATS_INTERVAL = 60
 
+#: Maximum number of cycles to skip the stats request in case of
+#: overlapping/pending stats replies
+STATS_REQ_SKIP = 5
+
 #: Supported Versions
 OPENFLOW_VERSIONS = [0x01, 0x04]
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -56,7 +56,7 @@ class TestMain(TestCase):
     def test_request_flow_list(self, *args):
         """Test request flow list."""
         (mock_update_flow_list_v0x01, mock_update_flow_list_v0x04) = args
-        mock_update_flow_list_v0x04.return_value = "ABC"
+        mock_update_flow_list_v0x04.return_value = 0xABC
         self.napp._request_flow_list(self.switch_v0x01)
         mock_update_flow_list_v0x01.assert_called_with(self.napp.controller,
                                                        self.switch_v0x01)
@@ -69,7 +69,7 @@ class TestMain(TestCase):
     def test_on_handshake_completed_request_flow_list(self, *args):
         """Test request flow list."""
         (mock_update_flow_list_v0x01, mock_update_flow_list_v0x04) = args
-        mock_update_flow_list_v0x04.return_value = "ABC"
+        mock_update_flow_list_v0x04.return_value = 0xABC
         name = 'kytos/of_core.handshake.completed'
         content = {"switch": self.switch_v0x01}
         event = get_kytos_event_mock(name=name, content=content)
@@ -217,7 +217,7 @@ class TestMain(TestCase):
         mock_switch = get_switch_mock(dpid)
         mock_switch.id = dpid
         self.napp._multipart_replies_flows = {dpid: mock_switch}
-        self.napp._multipart_replies_xids = {dpid: {'flows': mock_switch}}
+        self.napp._multipart_replies_xids = {dpid: {'flows': 0xABC}}
         self.napp._update_switch_flows(mock_switch)
         self.assertEqual(self.napp._multipart_replies_xids, {dpid: {}})
         self.assertEqual(self.napp._multipart_replies_flows, {})


### PR DESCRIPTION
Fixes #25 
Fixes #27 

### Description of the change

Added mechanism to prevent race conditions for the variable `connection.remaining_data`. This variable can be updated from two or more different threads handling `kytos/core.openflow.raw.in` KytosEvents. Thus, I've added a threading Lock mechanism per connection which will guarantee only one thread can update at the same time.

Additionally, the `handle_raw_in` method was creating one KytosEvent for each individual multipart OpenFlow message, which could lead to data loss as described in issue #25. To deal with such scenarios, I've changed the way handle_raw_in works for multipart message: instead of creating one KytosEvent as soon as the message was unpacked, we group them together and emit the Kytos event at the end; before emit the Kytos events for all the messages, we save the amount of messages that are expected to be received. Thus, the `handle_multipart_replies()` is now able to know how many parts should be received and it will wait a couple of seconds before assemble them all into the switch's FlowStats. The maximum wait interval is based on the existing setting STATS_INTERVAL (half of it).

### Release notes

- Added mechanism to prevent race conditions for connection remaining data (openflow messages received buffer)
- Improved the handling of openflow multipart messages, to avoid data loss between different event handlers (threads)