### PR TITLE
[Fix] OFPT_ERROR 'ErrorMsg' object has no attribute 'dpid'

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,9 +264,11 @@ class Main(KytosNApp):
             try:
                 message = connection.protocol.unpack(packet)
                 if message.header.message_type == Type.OFPT_ERROR:
-                    log.error(f"OFPT_ERROR: {message.code} error code received"
-                              f" from switch {message.dpid} with xid "
-                              f"{message.header.xid}/{message.header.xid:x}")
+                    code = message.code
+                    header_xid = message.header.xid
+                    log.error(f"OFPT_ERROR: type {message.error_type}, error"
+                              f" code {code}, from switch {switch.id}, xid "
+                              f"{header_xid}/{header_xid.value:x}")
             except (UnpackException, AttributeError) as err:
                 log.error(err)
                 if isinstance(err, AttributeError):


### PR DESCRIPTION
Fixes #34 

### Description of the change

- Updated the log error message passing the expected vars accordingly

Example with this fix, when trying to reproduce the original error on #34: 

```
2021-11-26 12:57:51,836 - ERROR [kytos.napps.kytos/of_core] (Thread-175) OFPT_ERROR: type ErrorType.OFPET_BAD_MATCH, error code 7, from switch 00:00:00:00:00:00:00:01, xid 881795134/348f203e
```