### PR TITLE
[Fix] Fixed failing unit tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -435,9 +435,10 @@ class Main(KytosNApp):
     @listen_to('kytos/of_core.v0x0[14].messages.out.ofpt_features_request')
     def on_features_request_sent(self, event):
         """Ensure request has actually been sent before changing state."""
-        self.handle_features_request_sent
+        self.handle_features_request_sent(event)
 
-    def handle_features_request_sent(self, event):
+    @classmethod
+    def handle_features_request_sent(cls, event):
         """Ensure request has actually been sent before changing state."""
         if event.destination.protocol.state == 'sending_features':
             event.destination.protocol.state = 'waiting_features_reply'
@@ -448,7 +449,8 @@ class Main(KytosNApp):
         """Close the connection upon hello failure."""
         self.handle_openflow_in_hello_failed(event)
 
-    def handle_openflow_in_hello_failed(self, event):
+    @classmethod
+    def handle_openflow_in_hello_failed(cls, event):
         """Close the connection upon hello failure."""
         event.destination.close()
         log.debug("Connection %s: Connection closed.", event.destination.id)

--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ class Main(KytosNApp):
             event (:class:`~kytos.core.events.KytosEvent):
                 Event with ofpt_stats_reply in message.
         """
-        self.on_stats_reply(event)
+        self.handle_stats_reply(event)
 
     def handle_stats_reply(self, event):
         """Handle stats replies for v0x01 switches."""

--- a/main.py
+++ b/main.py
@@ -84,7 +84,6 @@ class Main(KytosNApp):
 
     def handle_stats_reply(self, event):
         """Handle stats replies for v0x01 switches."""
-
         switch = event.source.switch
         msg = event.content['message']
         if msg.body_type == StatsType.OFPST_FLOW:
@@ -160,7 +159,6 @@ class Main(KytosNApp):
 
     def handle_multipart_reply(self, event):
         """Handle multipart replies for v0x04 switches."""
-
         reply = event.content['message']
         switch = event.source.switch
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-comprehension --ignored-modules=napps.kytos.of_core
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-comprehension,too-many-public-methods --ignored-modules=napps.kytos.of_core
 
 [pydocstyle]
 add-ignore = D105


### PR DESCRIPTION
Fixes #27 that @italovalcy has reported

### Description of the change

- We've had some failing assert calls on `listen_to` decorators being these were being tested out directly, and depending on the threadpool queue/scheduler there's no guarantee it'll be immediately or shortly after executed, since we don't expose a `join/result`, the safest route to be deterministic was to extract the `listen_to` handlers in new methods, and test hem out without depending on threading spawn execution times. 


