### PR TITLE
[Fix] Updated switch `lastseen` before sending `kytos/of_core.handshake.completed`

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ class Main(KytosNApp):
         connection = event.source
         version_utils = self.of_core_version_utils[connection.protocol.version]
         switch = version_utils.handle_features_reply(self.controller, event)
+        switch.update_lastseen()
 
         if (connection.is_during_setup() and
                 connection.protocol.state == 'waiting_features_reply'):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -167,7 +167,11 @@ class TestMain(TestCase):
         name = 'kytos/of_core.v0x0[14].messages.in.ofpt_features_reply'
         content = {"source": self.switch_v0x01.connection}
         event = get_kytos_event_mock(name=name, content=content)
+        count = self.switch_v0x01.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 0)
         self.napp.handle_features_reply(event)
+        count = self.switch_v0x01.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 1)
         mock_freply_v0x01.assert_called_with(self.napp.controller, event)
         mock_send_desc_request_v0x01.assert_called_with(
             self.napp.controller, self.switch_v0x01.connection.switch)
@@ -178,7 +182,11 @@ class TestMain(TestCase):
         self.switch_v0x04.connection.protocol.state = 'waiting_features_reply'
         content = {"source": self.switch_v0x04.connection}
         event = get_kytos_event_mock(name=name, content=content)
+        count = self.switch_v0x04.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 0)
         self.napp.handle_features_reply(event)
+        count = self.switch_v0x04.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 1)
         mock_freply_v0x04.assert_called_with(self.napp.controller, event)
         mock_send_desc_request_v0x04.assert_called_with(
             self.napp.controller, self.switch_v0x04.connection.switch)


### PR DESCRIPTION
Fixes #38 

### Description of the change

- Updated switch `lastseen` right after the underlying `get_switch_or_create(dpid, conn)` call and before sending `kytos/of_core.handshake.completed`, just so the `is_connected()` method works as intended. 


### Release notes

- Updated switch `lastseen`  before sending `kytos/of_core.handshake.completed`, to fix the `is_connected()` method check.