### PR TITLE
[Fix] `update_port_status` on `OFPPR_DELETE` to deactivate an interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,12 @@ Fixed
 Security
 ========
 
+[1.7.0] - 2022-01-04
+********************
+
+Changed
+=======
+- Changed ``update_port_status`` on ``OFPPR_DELETE`` to deactivate an interface instead of deleting it to keep the same object reference that ``topology`` uses when managing the status of a link.
 
 [1.6.1] - 2021-05-26
 ********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/main.py
+++ b/main.py
@@ -675,7 +675,7 @@ class Main(KytosNApp):
         elif reason == 'OFPPR_DELETE':
             status = 'deleted'
             interface = source.switch.get_interface_by_port_no(port_no)
-            source.switch.remove_interface(interface)
+            interface.deactivate()
 
         event_name += status
         content = {'interface': interface}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -624,7 +624,10 @@ class TestMain(TestCase):
         mock_buffer_put.assert_called()
 
         # check OFPRR_DELETE
+        mock_intf = MagicMock()
+        mock_source.switch.get_interface_by_port_no.return_value = mock_intf
         mock_port_status.reason.enum_ref(2).name = 'OFPPR_DELETE'
         self.napp.update_port_status(mock_port_status, mock_source)
         mock_port_mod.assert_called()
         mock_buffer_put.assert_called()
+        mock_intf.deactivate.assert_called()


### PR DESCRIPTION
Fixes #20, this addressed the first requirement, the other two ones were broken down to be addressed [on issue 39 on topology](https://github.com/kytos-ng/topology/issues/39):

### Description of the change

`[1.7.0] - 2022-01-04`

#### Changed
- Changed ``update_port_status`` on ``OFPPR_DELETE`` to deactivate an interface instead of deleting it to keep the same object reference that ``topology`` uses when managing the status of a link.


### Local exploratory test

- Before shutting down mininet, all interfaces are active from the topology perspective:

```
❯ http http://127.0.0.1:8181/api/kytos/topology/v3/interfaces | jq -r '.interfaces[].active'
true
true
true
true
true
true
true
true
true
true
```

- After shutting down mininet, all interfaces are active from the topology perspective (the only ones UP are `OFPP_LOCAL`):

```
❯ http http://127.0.0.1:8181/api/kytos/topology/v3/interfaces | jq -r '.interfaces[].active'
false
false
true
false
false
false
true
false
false
true
```
- After all switches reconnect again:

```
❯ http http://127.0.0.1:8181/api/kytos/topology/v3/interfaces | jq -r '.interfaces[].active'
true
true
true
true
true
true
true
true
true
true
````

