### PR TITLE
[Fix] setup.py install_requires dependencies housekeeping

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = .eggs/*,.tox/*,*tests*,setup.py
+omit = .eggs/*,.tox/*,*tests*,setup.py,.direnv/*,.venv/*,venv/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 [yala]
 radon mi args = --min C
 pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-comprehension,too-many-public-methods --ignored-modules=napps.kytos.of_core
+linters=pylint,pycodestyle,isort
 
 [pydocstyle]
 add-ignore = D105

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ class EggInfo(egg_info):
         """Python wheels are much faster (no compiling)."""
         print('Installing dependencies...')
         check_call([sys.executable, '-m', 'pip', 'install', '-r',
-                    'requirements/run.in'])
+                    'requirements/run.txt'])
 
 
 class DevelopMode(develop):
@@ -265,6 +265,16 @@ def read_version_from_json():
     return metadata['version']
 
 
+def read_requirements(path="requirements/run.txt"):
+    """Read requirements file and return a list."""
+    with open(path, "r", encoding="utf8") as file:
+        return [
+            line.strip()
+            for line in file.readlines()
+            if not line.startswith("#")
+        ]
+
+
 setup(name='kytos_of_core',
       version=read_version_from_json(),
       description='Core NApps developed by Kytos Team',
@@ -272,6 +282,7 @@ setup(name='kytos_of_core',
       author='Kytos Team',
       author_email='of-ng-dev@ncc.unesp.br',
       license='MIT',
+      install_requires=read_requirements(),
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],
       extras_require={


### PR DESCRIPTION
- [Same as `storehouse` PR #6](https://github.com/kytos-ng/storehouse/pull/6), `of_core` didn't have extra runtime dependencies, but with the `install_requires` in place it's normalized now like the other NApps.
- I'll regenerate and upgrade the `requirements/dev.txt` in a next opportunity on issue #43 