### PR TITLE
[Fix] `update_lastseen()` on features reply (PR 41 cherry picked)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,14 @@ Fixed
 Security
 ========
 
+[2022.1.1] - 2022-02-03
+***********************
+
+Changed
+=======
+- Added ``switch.update_lastseen()`` on handle_features_reply
+
+
 [1.7.0] - 2022-01-04
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2022.1.0",
+  "version": "2022.1.1",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/main.py
+++ b/main.py
@@ -165,6 +165,7 @@ class Main(KytosNApp):
         connection = event.source
         version_utils = self.of_core_version_utils[connection.protocol.version]
         switch = version_utils.handle_features_reply(self.controller, event)
+        switch.update_lastseen()
 
         if (connection.is_during_setup() and
                 connection.protocol.state == 'waiting_features_reply'):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -236,7 +236,11 @@ class TestMain(TestCase):
         name = 'kytos/of_core.v0x0[14].messages.in.ofpt_features_reply'
         content = {"source": self.switch_v0x01.connection}
         event = get_kytos_event_mock(name=name, content=content)
+        count = self.switch_v0x01.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 0)
         self.napp.handle_features_reply(event)
+        count = self.switch_v0x01.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 1)
         mock_freply_v0x01.assert_called_with(self.napp.controller, event)
         mock_send_desc_request_v0x01.assert_called_with(
             self.napp.controller, self.switch_v0x01.connection.switch)
@@ -247,7 +251,11 @@ class TestMain(TestCase):
         self.switch_v0x04.connection.protocol.state = 'waiting_features_reply'
         content = {"source": self.switch_v0x04.connection}
         event = get_kytos_event_mock(name=name, content=content)
+        count = self.switch_v0x04.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 0)
         self.napp.handle_features_reply(event)
+        count = self.switch_v0x04.connection.switch.update_lastseen.call_count
+        self.assertEqual(count, 1)
         mock_freply_v0x04.assert_called_with(self.napp.controller, event)
         mock_send_desc_request_v0x04.assert_called_with(
             self.napp.controller, self.switch_v0x04.connection.switch)


### PR DESCRIPTION
This change was fixed and supposed to land on PR #41, however back then it got merged into a branch that had already landed, so it never made to master, so I'm cherry picking the commits again. Having `Automatically delete head branches` enabled, which we do now should prevent this from happening again when there are multiple branches on top of each other. 

## Release notes

[2022.1.1] - 2022-02-03
***********************

#### Changed
- Added ``switch.update_lastseen()`` on handle_features_reply