### PR TITLE
Added new `kytos/of_core.switch.interfaces.created` event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Added
 =====
+- Added new KytosEvent ``kytos/of_core.switch.interfaces.created`` meant for bulk updates or insertions.
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,36 @@ Content:
     'interface': <interface> # Instance of Interface class
    }
 
+
+kytos/of_core.switch.interface.created
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting that an interface was created.
+
+Content:
+
+.. code-block:: python
+
+   {
+    'interface': <interface> # Instance of Interface class
+   }
+
+
+kytos/of_core.switch.interfaces.created
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting that interfaces were created.
+
+It's meant to facilitate bulk updates or inserts.
+
+Content:
+
+.. code-block:: python
+
+   {
+    'interfaces': [<interface>] # Instance of Interface class
+   }
+
 kytos/of_core.reachable.mac
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/unit/v0x04/test_utils.py
+++ b/tests/unit/v0x04/test_utils.py
@@ -51,7 +51,7 @@ class TestUtils(TestCase):
         call_count = self.mock_switch.update_or_create_interface.call_count
         self.assertEqual(call_count, 1)
         mock_event_buffer.assert_called()
-        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 2)
+        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 3)
 
         self.mock_switch.update_or_create_interface.call_count = 0
         self.mock_controller.buffers.app.put.call_count = 0
@@ -59,7 +59,7 @@ class TestUtils(TestCase):
         call_count = self.mock_switch.update_or_create_interface.call_count
         self.assertEqual(call_count, 1)
         mock_event_buffer.assert_called()
-        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 2)
+        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 3)
 
     @patch('napps.kytos.of_core.v0x04.utils.emit_message_out')
     def test_send_echo(self, mock_emit_message_out):

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -99,6 +99,7 @@ def handle_features_reply(controller, event):
 
 def handle_port_desc(controller, switch, port_list):
     """Update interfaces on switch based on port_list information."""
+    interfaces = []
     for port in port_list:
         config = port.config
         if (port.supported == 0 and
@@ -114,6 +115,7 @@ def handle_port_desc(controller, switch, port_list):
                         features=port.curr,
                         config=config,
                         speed=port.curr_speed.value)
+        interfaces.append(interface)
 
         event_name = 'kytos/of_core.switch.interface.created'
         interface_event = KytosEvent(name=event_name,
@@ -129,6 +131,11 @@ def handle_port_desc(controller, switch, port_list):
                                         }
                                     })
         controller.buffers.app.put(port_event)
+        controller.buffers.app.put(interface_event)
+    if interfaces:
+        event_name = 'kytos/of_core.switch.interfaces.created'
+        interface_event = KytosEvent(name=event_name,
+                                     content={'interfaces': interfaces})
         controller.buffers.app.put(interface_event)
 
 


### PR DESCRIPTION
Fixes #52 

- Added new KytosEvent ``kytos/of_core.switch.interfaces.created`` meant for bulk updates or insertions.

I realized this opportunity when I was implementing the DB updates and insertions on topology, so now subscribers who can benefit from it can subscribe accordingly. 