### PR TITLE
fix setup.py egg_info with python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,6 +283,7 @@ setup(name='kytos_of_core',
       author_email='of-ng-dev@ncc.unesp.br',
       license='MIT',
       install_requires=read_requirements(),
+      packages=[],
       setup_requires=['pytest-runner'],
       tests_require=['pytest==7.0.0'],
       extras_require={


### PR DESCRIPTION
Fix #58 
Running the command `python setup.py egg_info ` returns an error.
This PR intend to fix this issue, adding the parameter `packages=[]` to the setup command.
It must solve dependency issues when running `pip-compile `in other NApps.