### PR TITLE
[Feature] Added `Flow` `match_id` attribute for efficient overlapping matches updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Added
 
 Changed
 =======
-- Changed OF10 ``as_dict`` to only included explicit set values
+- Changed Match OF10 ``as_dict`` to only included explicit set values
 
 Deprecated
 ==========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,9 +9,11 @@ All notable changes to the of_core NApp will be documented in this file.
 Added
 =====
 - Added new KytosEvent ``kytos/of_core.switch.interfaces.created`` meant for bulk updates or insertions.
+- Added ``match_id`` attribute on ``Flow``  as a unique match identifier for efficient overlapping matches updates, minimizing extra DB lookups that would be needed otherwise.
 
 Changed
 =======
+- Changed OF10 ``as_dict`` to only included explicit set values
 
 Deprecated
 ==========

--- a/flow.py
+++ b/flow.py
@@ -95,6 +95,36 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
         md5sum.update(flow_str.encode('utf-8'))
         return md5sum.hexdigest()
 
+    @property
+    def match_id(self):
+        """Return this flow unique match identifier.
+
+        This is meant for effecient strict match lookups.
+
+        Returns:
+            str: Flow unique identifier (md5sum).
+
+        """
+        match_field = self.match.as_dict()
+        match_field.pop('instructions', None)
+        flow_match_fields = {
+            'switch': self.switch.id,
+            'table_id': self.table_id,
+            'match': self.match.as_dict(),
+            'priority': self.priority,
+            'cookie': self.cookie,
+        }
+        version = self.switch.connection.protocol.version
+        if version == 0x01:
+            flow_str = json.dumps(flow_match_fields,
+                                  cls=v0x01.utils.JSONEncoderOF10,
+                                  sort_keys=True)
+        else:
+            flow_str = json.dumps(flow_match_fields, sort_keys=True)
+        md5sum = md5()
+        md5sum.update(flow_str.encode('utf-8'))
+        return md5sum.hexdigest()
+
     def as_dict(self, include_id=True):
         """Return the Flow as a serializable Python dictionary.
 

--- a/flow.py
+++ b/flow.py
@@ -99,14 +99,12 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
     def match_id(self):
         """Return this flow unique match identifier.
 
-        This is meant for effecient strict match lookups.
+        This is meant for effecient overlapping match updates or insertions.
 
         Returns:
-            str: Flow unique identifier (md5sum).
+            str: Flow unique match identifier (md5sum).
 
         """
-        match_field = self.match.as_dict()
-        match_field.pop('instructions', None)
         flow_match_fields = {
             'switch': self.switch.id,
             'table_id': self.table_id,

--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ class Main(KytosNApp):
         """
         switch = event.content['switch']
         if switch.is_enabled():
-            self._request_flow_list(switch)
+            self.handle_handshake_completed_request_flow_list(switch)
 
     def handle_handshake_completed_request_flow_list(self, switch):
         """Request an flow list right after the handshake is completed."""

--- a/main.py
+++ b/main.py
@@ -192,6 +192,10 @@ class Main(KytosNApp):
         if switch.is_enabled():
             self._request_flow_list(switch)
 
+    def handle_handshake_completed_request_flow_list(self, switch):
+        """Request an flow list right after the handshake is completed."""
+        self._request_flow_list(switch)
+
     @listen_to('kytos/of_core.v0x04.messages.in.ofpt_multipart_reply')
     def on_multipart_reply(self, event):
         """Handle multipart replies for v0x04 switches.

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from kytos.lib.helpers import get_connection_mock, get_switch_mock
 from napps.kytos.of_core.v0x01.flow import Flow as Flow01
-from napps.kytos.of_core.v0x04.flow import Flow as Flow04, Match as Match04
+from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from napps.kytos.of_core.v0x04.flow import Match as Match04
 
 
 class TestFlowFactory(TestCase):
@@ -188,7 +189,8 @@ class TestFlow(TestCase):
                 self.assertEqual(response.hard_timeout,
                                  self.requested['hard_timeout'])
 
-    def test_match_id(self):
+    @staticmethod
+    def test_match_id():
         """Test match_id."""
         dpid = "00:00:00:00:00:00:00:01"
         mock_switch = get_switch_mock(dpid, 0x04)

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from kytos.lib.helpers import get_connection_mock, get_switch_mock
 from napps.kytos.of_core.v0x01.flow import Flow as Flow01
-from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from napps.kytos.of_core.v0x04.flow import Flow as Flow04, Match as Match04
 
 
 class TestFlowFactory(TestCase):
@@ -187,6 +187,27 @@ class TestFlow(TestCase):
                                  self.requested['idle_timeout'])
                 self.assertEqual(response.hard_timeout,
                                  self.requested['hard_timeout'])
+
+    def test_match_id(self):
+        """Test match_id."""
+        dpid = "00:00:00:00:00:00:00:01"
+        mock_switch = get_switch_mock(dpid, 0x04)
+        mock_switch.id = dpid
+        flow_one = {"match": Match04(**{"in_port": 1, "dl_vlan": 2})}
+        flow_two = {"match": Match04(**{"in_port": 1, "dl_vlan": 2})}
+        flow_three = {"match": Match04(**{"in_port": 1, "dl_vlan": 3})}
+
+        assert Flow04(mock_switch, **flow_one).match_id == Flow04(
+            mock_switch, **flow_two
+        ).match_id
+        assert Flow04(mock_switch, **flow_one).match_id != Flow04(
+            mock_switch, **flow_three
+        ).match_id
+
+        flow_two["cookie"] = 0x10
+        assert Flow04(mock_switch, **flow_one).match_id != Flow04(
+            mock_switch, **flow_two
+        ).match_id
 
 
 class TestFlowBase(TestCase):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,7 +13,7 @@ from napps.kytos.of_core.utils import NegotiationException
 from tests.helpers import get_controller_mock
 
 
-# pylint: disable=protected-access, too-many-public-methods
+# pylint: disable=protected-access, too-many-public-methods, invalid-name
 class TestMain(TestCase):
     """Test the Main class."""
 
@@ -139,15 +139,12 @@ class TestMain(TestCase):
         """Test request flow list."""
         (mock_update_flow_list_v0x01, mock_update_flow_list_v0x04, _) = args
         mock_update_flow_list_v0x04.return_value = 0xABC
-        name = 'kytos/of_core.handshake.completed'
-        content = {"switch": self.switch_v0x01}
-        event = get_kytos_event_mock(name=name, content=content)
-        self.napp.on_handshake_completed_request_flow_list(event)
+        sw = self.switch_v0x01
+        self.napp.handle_handshake_completed_request_flow_list(sw)
         mock_update_flow_list_v0x01.assert_called_with(self.napp.controller,
                                                        self.switch_v0x01)
-        content = {"switch": self.switch_v0x04}
-        event = get_kytos_event_mock(name=name, content=content)
-        self.napp.on_handshake_completed_request_flow_list(event)
+        sw = self.switch_v0x04
+        self.napp.handle_handshake_completed_request_flow_list(sw)
         mock_update_flow_list_v0x04.assert_called_with(self.napp.controller,
                                                        self.switch_v0x04)
 

--- a/tests/unit/test_match.py
+++ b/tests/unit/test_match.py
@@ -86,3 +86,9 @@ class TestMatch(TestCase):
             Match04.from_of_match(match.as_of_match()).as_dict(),
             self.EXPECTED_OF_13
         )
+
+    def test_match01_as_dict(self) -> None:
+        """Test match01 as_dict."""
+        match_values = {'in_port': 1, 'dl_vlan': 2}
+        match_01 = Match01(**match_values)
+        assert len(match_01.as_dict()) == len(match_values)

--- a/tests/unit/test_match.py
+++ b/tests/unit/test_match.py
@@ -91,4 +91,4 @@ class TestMatch(TestCase):
         """Test match01 as_dict."""
         match_values = {'in_port': 1, 'dl_vlan': 2}
         match_01 = Match01(**match_values)
-        assert len(match_01.as_dict()) == len(match_values)
+        self.assertEqual(len(match_01.as_dict()), len(match_values))

--- a/v0x01/flow.py
+++ b/v0x01/flow.py
@@ -1,4 +1,5 @@
 """Deal with OpenFlow 1.0 specificities related to flows."""
+from pyof.foundation.basic_types import UBInt8, UBInt16
 from pyof.v0x01.common.action import ActionOutput as OFActionOutput
 from pyof.v0x01.common.action import ActionVlanVid as OFActionVlanVid
 from pyof.v0x01.common.flow_match import Match as OFMatch
@@ -37,6 +38,26 @@ class Match(MatchBase):
             if value is not None:
                 setattr(match, field, value)
         return match
+
+    def as_dict(self):
+        """Return dict representation."""
+        default_fields = {
+          'in_port': UBInt16(0),
+          'dl_src': '00:00:00:00:00:00',
+          'dl_dst': '00:00:00:00:00:00',
+          'dl_vlan': UBInt16(0),
+          'dl_vlan_pcp': UBInt8(0),
+          'dl_type': UBInt16(0),
+          'nw_proto': UBInt8(0),
+          'nw_src': '0.0.0.0',
+          'nw_dst': '0.0.0.0',
+          'tp_src': UBInt16(0),
+          'tp_dst': UBInt16(0)
+        }
+        return {
+            k: v for k, v in super().as_dict().items()
+            if v is not None and k in default_fields and v != default_fields[k]
+        }
 
 
 class ActionOutput(ActionBase):


### PR DESCRIPTION
### Description of the change

### Release notes

- Added ``match_id`` attribute on ``Flow`` as a unique match identifier for efficient overlapping matches updates, minimizing extra DB lookups that would be needed otherwise.
- Match OF10 ``as_dict`` to only included explicit set values.

This picture illustrates a `POST /api/kytos/flow_manager/v2/flows/` on `flow_manager` (that's in progress on https://github.com/kytos-ng/flow_manager/issues/75), by leveraging this `match_id` there's a single update, minimizing DB round trips when inserting or updating a flow, minimizing locks and delegating as much to Mongo whenever applicable

![fmanager_mongo](https://user-images.githubusercontent.com/1010796/169145235-b7b0266b-5d84-423e-a1b8-d61bfb2320c5.png)


I wasn't going to support OF10 either on this attribute, since we have mapped the issues to deprecate it, but since we haven't yet and the fix was simple I committed it. We can drop OF1.0 on issue #50 .