### PR TITLE
[Fix] Handler kytos/core.openflow.raw.in crashed when trying to log an OFPT_ERROR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Removed
 
 Fixed
 =====
+- OFPT_ERROR message could crash when logging it.
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -348,8 +348,7 @@ class Main(KytosNApp):
                         log.error(f"OFPT_ERROR: type {message.error_type},"
                                   f" error code {message.code},"
                                   f" from switch {switch.id},"
-                                  f" xid {message.header.xid}/"
-                                  f"{message.header.xid:x}")
+                                  f" xid {message.header.xid}")
                 except (UnpackException, AttributeError) as err:
                     log.error(err)
                     if isinstance(err, AttributeError):

--- a/main.py
+++ b/main.py
@@ -348,7 +348,8 @@ class Main(KytosNApp):
                         log.error(f"OFPT_ERROR: type {message.error_type},"
                                   f" error code {message.code},"
                                   f" from switch {switch.id},"
-                                  f" xid {message.header.xid}")
+                                  f" xid {message.header.xid}/"
+                                  f"0x{message.header.xid.value:x}")
                 except (UnpackException, AttributeError) as err:
                     log.error(err)
                     if isinstance(err, AttributeError):


### PR DESCRIPTION
Fixes #61 

Now it correctly logs and then publishes the OFPT_ERROR message, I removed the hex f-string format, it was there primarily for convenience.

This branch is on top of #60 to facilitate local development and managing in-flight branches.

### Release notes

- OFPT_ERROR message could crash when logging it.

### Running it locally

```
2022-05-19 16:01:02,889 - ERROR [kytos.napps.kytos/of_core] (thread_pool_sb_7) OFPT_ERROR: type ErrorType.OFPET_BAD_MATCH, error code 7, from switch 00:00:00:00:00:00:00:01, xid 130177
2539
2022-05-19 16:01:02,894 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_7) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'dl_vlan': 10000}, '
priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 0, 'id': '502866b8912c0eee9e98345b01013524', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'app
ly_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}, xid: 1301772539, cookie: 0, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_MATCH: 4>), 'e
rror_code': <BadMatchCode.OFPBMC_BAD_VALUE: 7>}
kytos $>
```
