### PR TITLE
[Fix] Flow04 inconsistent id for empty actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Removed
 Fixed
 =====
 - OFPT_ERROR message could crash when logging it.
+- Fixed inconsistent Flow04 id for empty list actions.
 
 Security
 ========

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -2,10 +2,43 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from kytos.lib.helpers import get_connection_mock, get_switch_mock
 from napps.kytos.of_core.v0x01.flow import Flow as Flow01
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
 from napps.kytos.of_core.v0x04.flow import Match as Match04
+
+
+@pytest.mark.parametrize(
+    "flow1_dict, flow2_dict",
+    [
+        (
+            {"match": {"in_port": 1, "dl_vlan": 105}, "actions": []},
+            {"match": {"in_port": 1, "dl_vlan": 105}},
+        ),
+        (
+            {
+                "match": {},
+                "cookie": 0,
+                "table_id": 0,
+                "priority": 0x8000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+            },
+            {"match": {}},
+        )
+    ],
+)
+def test_equivalent_flow_ids(flow1_dict, flow2_dict):
+    """Test equivalent flow ids."""
+    switch = MagicMock()
+    dpid = "00:00:00:00:00:00:00:01"
+    switch.id = dpid
+    flow1 = Flow04.from_dict(flow1_dict, switch)
+    flow2 = Flow04.from_dict(flow2_dict, switch)
+    assert flow1.as_dict(include_id=False) == flow2.as_dict(include_id=False)
+    assert flow1.id == flow2.id
 
 
 class TestFlowFactory(TestCase):

--- a/v0x04/flow.py
+++ b/v0x04/flow.py
@@ -356,7 +356,7 @@ class Flow(FlowBase):
         """Create a Flow instance from a dictionary."""
         flow = super().from_dict(flow_dict, switch)
         flow.instructions = []
-        if 'actions' in flow_dict:
+        if 'actions' in flow_dict and flow_dict['actions']:
             instruction_apply_actions = InstructionApplyAction()
             for action_dict in flow_dict['actions']:
                 action = cls._action_factory.from_dict(action_dict)


### PR DESCRIPTION
Fixes #64 

- Fixed inconsistent Flow04 id for empty list actions, now the id is equivalent with the default values for this particular case.