### PR TITLE
[Feature] Added OpenFlow msg_prios module for core queues priorities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Added new KytosEvent ``kytos/of_core.switch.interfaces.created`` meant for bulk updates or insertions.
 - Added ``match_id`` attribute on ``Flow``  as a unique match identifier for efficient overlapping matches updates, minimizing extra DB lookups that would be needed otherwise.
+- Added msg_prios module to define OpenFlow message priorities used in the core queues and covered with unit tests
 
 Changed
 =======

--- a/msg_prios.py
+++ b/msg_prios.py
@@ -1,0 +1,15 @@
+"""OpenFlow message priorities used in the core queues."""
+
+from pyof.v0x04.common.header import Type
+
+
+def of_msg_prio(msg_type: int) -> int:
+    """Get OpenFlow message priority.
+
+    The lower the number the higher the priority, if same priority, then it
+    will be ordered ascending by KytosEvent timestamp."""
+    prios = {
+        Type.OFPT_FLOW_MOD.value: 1000,
+        Type.OFPT_BARRIER_REQUEST.value: 1000
+    }
+    return prios.get(msg_type, 0)

--- a/tests/unit/test_msg_prios.py
+++ b/tests/unit/test_msg_prios.py
@@ -1,0 +1,24 @@
+"""Test msg_prios module."""
+
+import pytest
+from pyof.v0x04.common.header import Type
+
+from napps.kytos.of_core.msg_prios import of_msg_prio
+
+
+@pytest.mark.parametrize(
+    "msg_type,expected_prio",
+    [
+        (Type.OFPT_FLOW_MOD.value, 1000),
+        (Type.OFPT_BARRIER_REQUEST.value, 1000),
+    ],
+)
+def test_of_msg_prios(msg_type, expected_prio):
+    """test of_msg_prio."""
+    assert of_msg_prio(msg_type) == expected_prio
+
+
+def test_of_msg_default_prio():
+    """test of_msg_prio default value."""
+    vals = [val for val in Type.__dict__.values() if isinstance(val, int)]
+    assert of_msg_prio(vals[-1].value + 1) == 0


### PR DESCRIPTION
### Description of the change

- Added msg_prios module to define OpenFlow message priorities used in the core queues and covered with unit tests

Currently, only the `msg_out` queue is making use of priority, see this infrastructure/core PR https://github.com/kytos-ng/kytos/pull/226. In the future, we'll also have it for `msg_in`, and then we'll keep defining the rest of the OpenFlow message priorities that are primarily used as needed. NApps that put OpenFlow messages (`flow_manager`, `of_lldp`, `sdntrace`, and so on) are supposed to import and use this `msg_prios` module to get the message priority. 