### PR TITLE
[Fix] Extracted request_flow_list for testability

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,12 +64,17 @@ class Main(KytosNApp):
         """
         for switch in self.controller.switches.values():
             if switch.is_connected():
-                self._request_flow_list(switch)
+                self.request_flow_list(switch)
                 if settings.SEND_ECHO_REQUESTS:
                     version_utils = \
                         self.of_core_version_utils[switch.
                                                    connection.protocol.version]
                     version_utils.send_echo(self.controller, switch)
+
+    @run_on_thread
+    def request_flow_list(self, switch):
+        """Send flow stats request to a connected switch."""
+        self._request_flow_list(switch)
 
     def _check_overlapping_multipart_request(self, switch):
         """Check overlapping multipart stats request (OF 1.3 only)."""
@@ -98,7 +103,6 @@ class Main(KytosNApp):
         self.switch_req_stats_delay['last'] = next_delay
         return next_delay
 
-    @run_on_thread
     def _request_flow_list(self, switch):
         """Send flow stats request to a connected switch."""
         time.sleep(self._get_switch_req_stats_delay(switch))

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -339,23 +339,25 @@ class TestMain(TestCase):
         self.addCleanup(patch.stopall)
         self.napp = Main(get_controller_mock())
 
-    @patch('time.sleep', return_value=None)
     @patch('napps.kytos.of_core.v0x01.utils.send_echo')
     @patch('napps.kytos.of_core.v0x04.utils.send_echo')
     def test_execute(self, *args):
         """Test execute."""
-        (mock_of_core_v0x04_utils, mock_of_core_v0x01_utils, _) = args
+        (mock_of_core_v0x04_utils, mock_of_core_v0x01_utils) = args
+        self.napp.request_flow_list = MagicMock()
         self.switch_v0x01.is_connected.return_value = True
         self.switch_v0x04.is_connected.return_value = True
         self.napp.controller.switches = {"00:00:00:00:00:00:00:01":
                                          self.switch_v0x01}
         self.napp.execute()
         mock_of_core_v0x01_utils.assert_called()
+        assert self.napp.request_flow_list.call_count == 1
 
         self.napp.controller.switches = {"00:00:00:00:00:00:00:01":
                                          self.switch_v0x04}
         self.napp.execute()
         mock_of_core_v0x04_utils.assert_called()
+        assert self.napp.request_flow_list.call_count == 2
 
     @patch('napps.kytos.of_core.main.settings')
     def test_check_overlapping_multipart_request(self, mock_settings):


### PR DESCRIPTION
Fixes #72 

- Extracted request_flow_list for testability

[This call here](https://github.com/kytos-ng/of_core/blob/fix/issue_72/main.py#L202) was also spawning an extra thread since it's already being called from a `listen_to` handler.  In the future, we might introduce more `async` methods and tasks, for now it's probably not worth on this part considering the efforts on refactoring tests too. 