### PR TITLE
[Release] Bumped 2022.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,27 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Added
 =====
+
+Changed
+=======
+
+Deprecated
+==========
+
+Removed
+=======
+
+Fixed
+=====
+
+Security
+========
+
+[2022.2.0] - 2022-08-05
+***********************
+
+Added
+=====
 - Added new KytosEvent ``kytos/of_core.switch.interfaces.created`` meant for bulk updates or insertions.
 - Added ``match_id`` attribute on ``Flow``  as a unique match identifier for efficient overlapping matches updates, minimizing extra DB lookups that would be needed otherwise.
 - Added msg_prios module to define OpenFlow message priorities used in the core queues and covered with unit tests
@@ -19,21 +40,11 @@ Changed
 - on_multipart_reply is now handled with an ``async`` method in line
 - Updated ``kytos/of_core.flow_stats.received`` to also include the replied flows
 - KytosEvent put in ``msg_in`` and ``msg_out`` now have priority based on their control plane importance to avoid starvation
-- Replaced kytos.core log instance with a new one for now
-
-Deprecated
-==========
-
-Removed
-=======
 
 Fixed
 =====
 - OFPT_ERROR message could crash when logging it.
 - Fixed inconsistent Flow04 id for empty list actions.
-
-Security
-========
 
 [2022.1.1] - 2022-02-03
 ***********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2022.1.1",
+  "version": "2022.2.0",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 """NApp responsible for the main OpenFlow basic operations."""
 
 import asyncio
-import logging
 import time
 from collections import defaultdict
 
@@ -12,7 +11,7 @@ from pyof.v0x01.common.header import Type
 from pyof.v0x01.controller2switch.common import StatsType
 from pyof.v0x04.controller2switch.common import MultipartType
 
-from kytos.core import KytosEvent, KytosNApp
+from kytos.core import KytosEvent, KytosNApp, log
 from kytos.core.connection import ConnectionState
 from kytos.core.helpers import alisten_to, listen_to, run_on_thread
 from kytos.core.interface import Interface
@@ -25,9 +24,6 @@ from napps.kytos.of_core.v0x01 import utils as of_core_v0x01_utils
 from napps.kytos.of_core.v0x01.flow import Flow as Flow01
 from napps.kytos.of_core.v0x04 import utils as of_core_v0x04_utils
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
-
-# pylint: disable=invalid-name
-log = logging.getLogger("kytos.napps.kytos/of_core")
 
 
 class Main(KytosNApp):


### PR DESCRIPTION
- Bumped 2022.2.0
- Reverted temporary `logging.getLogger` since this PR https://github.com/kytos-ng/kytos/pull/257 has landed