### PR TITLE
[Release][Fix] Made a shallow copy when iterating on switches to avoid RuntimeError dictionary changed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,14 @@ Fixed
 Security
 ========
 
+[2022.2.1] - 2022-08-15
+***********************
+
+Fixed
+=====
+- Made a shallow copy when iterating on switches to avoid RuntimeError dictionary changed
+
+
 [2022.2.0] - 2022-08-05
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2022.2.0",
+  "version": "2022.2.1",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ class Main(KytosNApp):
         The execute method is called by the run method of KytosNApp class.
         Users shouldn't call this method directly.
         """
-        for switch in self.controller.switches.values():
+        for switch in self.controller.switches.copy().values():
             if switch.is_connected():
                 self.request_flow_list(switch)
                 if settings.SEND_ECHO_REQUESTS:


### PR DESCRIPTION
Fixes #79 

- Made a shallow copy when iterating on switches to avoid RuntimeError dictionary changed
- Bumped 2022.2.1 (first patch of this version for this NApp)
- Updated changelog
