### PR TITLE
Upgrade core development dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -637,9 +637,9 @@ class Main(KytosNApp):
             interface = source.switch.get_interface_by_port_no(port_no)
             current_status = None
             if interface:
-                log.info('Modified %s %s:%s' %
-                         (interface, interface.switch.dpid,
-                          interface.port_number))
+                dpid = interface.switch.dpid
+                port_number = interface.port_number
+                log.info(f"Modified {interface} {dpid}:{port_number}")
                 current_status = interface.state
                 interface.state = port.state.value
                 interface.name = port.name.value
@@ -673,8 +673,8 @@ class Main(KytosNApp):
 def _get_version_from_bitmask(message_versions):
     """Get common version from hello message version bitmap."""
     try:
-        return max([version for version in message_versions
-                    if version in settings.OPENFLOW_VERSIONS])
+        return max((version for version in message_versions
+                    if version in settings.OPENFLOW_VERSIONS))
     except ValueError:
         return None
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in
@@ -12,14 +12,26 @@
     # via
     #   -r requirements/dev.in
     #   kytos
-astroid==2.3.3
+asgiref==3.5.2
+    # via
+    #   flask
+    #   kytos
+astroid==2.12.9
     # via pylint
+asttokens==2.0.8
+    # via
+    #   kytos
+    #   stack-data
 attrs==21.4.0
     # via pytest
 backcall==0.1.0
     # via
     #   ipython
     #   kytos
+bidict==0.22.0
+    # via
+    #   kytos
+    #   python-socketio
 black==22.3.0
     # via -r requirements/dev.in
 blinker==1.4
@@ -42,49 +54,54 @@ decorator==4.4.2
     # via
     #   ipython
     #   kytos
-    #   traitlets
+dill==0.3.4
+    # via pylint
 docopt==0.6.2
     # via yala
-docutils==0.17
+docutils==0.19
     # via
     #   kytos
     #   python-daemon
 elastic-apm[flask]==6.9.1
     # via kytos
+executing==1.0.0
+    # via
+    #   kytos
+    #   stack-data
 filelock==3.0.12
     # via tox
-flask==1.1.2
+flask[async]==2.1.3
     # via
     #   flask-cors
     #   flask-socketio
     #   kytos
-flask-cors==3.0.8
+flask-cors==3.0.10
     # via kytos
-flask-socketio==4.2.1
+flask-socketio==5.2.0
     # via kytos
+importlib-metadata==4.12.0
+    # via
+    #   flask
+    #   kytos
 iniconfig==1.1.1
     # via pytest
-ipython==7.13.0
+ipython==8.1.1
     # via kytos
-ipython-genutils==0.2.0
-    # via
-    #   kytos
-    #   traitlets
 isort==4.3.21
     # via
     #   pylint
     #   yala
-itsdangerous==1.1.0
+itsdangerous==2.1.2
     # via
     #   flask
     #   kytos
-janus==0.4.0
+janus==1.0.0
     # via kytos
 jedi==0.16.0
     # via
     #   ipython
     #   kytos
-jinja2==2.11.1
+jinja2==3.1.2
     # via
     #   flask
     #   kytos
@@ -94,9 +111,13 @@ lockfile==0.12.2
     # via
     #   kytos
     #   python-daemon
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via
     #   jinja2
+    #   kytos
+matplotlib-inline==0.1.6
+    # via
+    #   ipython
     #   kytos
 mccabe==0.6.1
     # via pylint
@@ -112,10 +133,6 @@ parso==0.6.2
     #   kytos
 pathspec==0.9.0
     # via black
-pathtools==0.1.2
-    # via
-    #   kytos
-    #   watchdog
 pexpect==4.8.0
     # via
     #   ipython
@@ -127,7 +144,9 @@ pickleshare==0.7.5
 pip-tools==4.5.1
     # via kytos-of-core
 platformdirs==2.5.2
-    # via black
+    # via
+    #   black
+    #   pylint
 pluggy==0.13.1
     # via
     #   pytest
@@ -140,6 +159,10 @@ ptyprocess==0.6.0
     # via
     #   kytos
     #   pexpect
+pure-eval==0.2.2
+    # via
+    #   kytos
+    #   stack-data
 py==1.10.0
     # via
     #   pytest
@@ -148,13 +171,13 @@ pycodestyle==2.5.0
     # via yala
 pydantic==1.9.0
     # via kytos
-pygments==2.8.1
+pygments==2.13.0
     # via
     #   ipython
     #   kytos
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via kytos
-pylint==2.4.4
+pylint==2.15.0
     # via yala
 pymongo==4.1.0
     # via kytos
@@ -169,26 +192,27 @@ pytest-asyncio==0.18.3
     # via -r requirements/dev.in
 pytest-cov==3.0.0
     # via kytos-of-core
-python-daemon==2.2.4
+python-daemon==2.3.1
     # via kytos
-python-engineio==3.12.1
+python-engineio==4.3.4
     # via
     #   kytos
     #   python-socketio
-python-socketio==4.5.1
+python-socketio==5.7.1
     # via
     #   flask-socketio
     #   kytos
-six==1.15.0
+six==1.16.0
     # via
-    #   astroid
+    #   asttokens
     #   flask-cors
     #   kytos
     #   pip-tools
-    #   python-engineio
-    #   python-socketio
     #   tox
-    #   traitlets
+stack-data==0.5.0
+    # via
+    #   ipython
+    #   kytos
 tenacity==8.0.1
     # via kytos
 toml==0.10.2
@@ -197,31 +221,38 @@ tomli==1.2.3
     # via
     #   black
     #   coverage
+    #   pylint
     #   pytest
+tomlkit==0.11.4
+    # via pylint
 tox==3.14.6
     # via kytos-of-core
-traitlets==4.3.3
+traitlets==5.3.0
     # via
     #   ipython
     #   kytos
-typing-extensions==4.0.1
+    #   matplotlib-inline
+typing-extensions>=4.0.1
     # via
+    #   astroid
     #   black
+    #   janus
     #   kytos
     #   pydantic
+    #   pylint
 urllib3==1.26.7
     # via
     #   elastic-apm
     #   kytos
 virtualenv==16.0.0
     # via tox
-watchdog==0.10.2
+watchdog==2.1.9
     # via kytos
 wcwidth==0.1.9
     # via
     #   kytos
     #   prompt-toolkit
-werkzeug==1.0.1
+werkzeug==2.0.3
     # via
     #   flask
     #   kytos
@@ -229,6 +260,10 @@ wrapt==1.11.2
     # via astroid
 yala==2.2.0
     # via kytos-of-core
+zipp==3.8.1
+    # via
+    #   importlib-metadata
+    #   kytos
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-comprehension,too-many-public-methods,unnecessary-pass,too-many-arguments,logging-format-interpolation,logging-not-lazy --ignored-modules=napps.kytos.of_core
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-comprehension,too-many-public-methods,unnecessary-pass,too-many-arguments,logging-format-interpolation,logging-not-lazy,import-error,no-name-in-module --ignored-modules=napps.kytos.of_core
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ class Test(TestCommand):
 
     def run(self):
         """Run tests."""
-        cmd = 'python3 -m pytest tests/ %s' % self.get_args()
+        cmd = f'python3 -m pytest tests/ {self.get_args()}'
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -111,7 +111,7 @@ class TestCoverage(Test):
         """Run tests quietly and display coverage report."""
         # pylint: disable=fixme
         # TODO revert this commit when issue 68 gets fixed
-        cmd = 'python3 -m pytest --cov=. tests/unit %s' % self.get_args()
+        cmd = f'python3 -m pytest --cov=. tests/unit {self.get_args()}'
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -217,7 +217,7 @@ def symlink_if_different(path, target):
 def read_version_from_json():
     """Read the NApp version from NApp kytos.json file."""
     file = Path('kytos.json')
-    metadata = json.loads(file.read_text())
+    metadata = json.loads(file.read_text(encoding="utf8"))
     return metadata['version']
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,15 @@
 
 import pytest
 
-from kytos.lib.helpers import get_switch_mock
+from kytos.lib.helpers import get_controller_mock, get_switch_mock
 from napps.kytos.of_core.main import Main
-from tests.helpers import get_controller_mock
+
+
+@pytest.fixture(autouse=True)
+def ev_loop(monkeypatch, event_loop) -> None:
+    """asyncio event loop autouse fixture."""
+    monkeypatch.setattr("asyncio.get_running_loop", lambda: event_loop)
+    yield event_loop
 
 
 @pytest.fixture

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,19 +3,9 @@ from unittest.mock import MagicMock, Mock
 
 from pyof.utils import unpack
 
-from kytos.core import Controller
-from kytos.core.config import KytosConfig
 from kytos.core.connection import Connection, ConnectionState
 from kytos.core.interface import Interface
 from kytos.core.switch import Switch
-
-
-def get_controller_mock():
-    """Return a controller mock."""
-    options = KytosConfig().options['daemon']
-    controller = Controller(options)
-    controller.log = Mock()
-    return controller
 
 
 def get_interface_mock(interface_name, port, *args, **kwargs):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -14,9 +14,10 @@ from pyof.v0x04.symmetric.echo_request import EchoRequest
 
 from kytos.core.connection import ConnectionState
 from kytos.core.events import KytosEvent
+from kytos.lib.helpers import get_controller_mock
 from napps.kytos.of_core.utils import GenericHello
-from tests.helpers import (get_connection_mock, get_controller_mock,
-                           get_interface_mock, get_switch_mock)
+from tests.helpers import (get_connection_mock, get_interface_mock,
+                           get_switch_mock)
 
 
 class TestMain(TestCase):
@@ -51,7 +52,7 @@ class TestMain(TestCase):
 
         actual_events = self.napp.listeners()
         for _event in expected_events:
-            self.assertIn(_event, actual_events, '%s' % _event)
+            self.assertIn(_event, actual_events, str(_event))
 
     def test_execute(self):
         """Test 'execute' main method."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,10 +8,9 @@ from pyof.v0x01.controller2switch.common import StatsType
 from pyof.v0x04.controller2switch.common import MultipartType
 
 from kytos.core.connection import ConnectionState
-from kytos.lib.helpers import (get_connection_mock, get_kytos_event_mock,
-                               get_switch_mock)
+from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
+                               get_kytos_event_mock, get_switch_mock)
 from napps.kytos.of_core.utils import NegotiationException
-from tests.helpers import get_controller_mock
 
 # pylint: disable=protected-access, invalid-name
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,13 +4,13 @@ from unittest.mock import MagicMock, patch
 
 from pyof.v0x04.common.header import Type
 
-from kytos.lib.helpers import get_connection_mock, get_switch_mock
+from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
+                               get_switch_mock)
 from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_core.utils import (GenericHello, _emit_message,
                                        _unpack_int, aemit_message_in,
                                        aemit_message_out, emit_message_in,
                                        emit_message_out, of_slicer)
-from tests.helpers import get_controller_mock
 
 
 @patch('kytos.core.buffers.KytosEventBuffer.aput')

--- a/tests/unit/v0x01/test_utils.py
+++ b/tests/unit/v0x01/test_utils.py
@@ -2,11 +2,11 @@
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from kytos.lib.helpers import get_connection_mock, get_switch_mock
+from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
+                               get_switch_mock)
 from napps.kytos.of_core.v0x01.utils import (handle_features_reply, say_hello,
                                              send_desc_request, send_echo,
                                              send_set_config)
-from tests.helpers import get_controller_mock
 
 
 class TestUtils(TestCase):

--- a/tests/unit/v0x04/test_utils.py
+++ b/tests/unit/v0x04/test_utils.py
@@ -2,13 +2,13 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kytos.lib.helpers import get_connection_mock, get_switch_mock
+from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
+                               get_switch_mock)
 from napps.kytos.of_core.v0x04.utils import (handle_features_reply,
                                              handle_port_desc, say_hello,
                                              send_desc_request, send_echo,
                                              send_port_request,
                                              send_set_config)
-from tests.helpers import get_controller_mock
 
 
 @patch('napps.kytos.of_core.v0x04.utils.aemit_message_out')

--- a/utils.py
+++ b/utils.py
@@ -52,6 +52,7 @@ async def _aemit_message(controller, connection, message, direction):
         raise Exception("direction must be 'in' or 'out'")
 
     name = message.header.message_type.name.lower()
+    # pylint: disable=consider-using-f-string
     hex_version = 'v0x%0.2x' % (message.header.version + 0)
     priority = of_msg_prio(message.header.message_type.value)
     of_event = KytosEvent(
@@ -74,6 +75,7 @@ def _emit_message(controller, connection, message, direction):
         raise Exception("direction must be 'in' or 'out'")
 
     name = message.header.message_type.name.lower()
+    # pylint: disable=consider-using-f-string
     hex_version = 'v0x%0.2x' % (message.header.version + 0)
     priority = of_msg_prio(message.header.message_type.value)
     of_event = KytosEvent(
@@ -199,8 +201,8 @@ class GenericHello:
                     packet, offset, elem_value_size)
 
                 elements[elem_type] = elem_value
-        except IndexError:
-            raise UnpackException
+        except IndexError as exc:
+            raise UnpackException from exc
 
         self.elements = elements
 

--- a/v0x01/utils.py
+++ b/v0x01/utils.py
@@ -19,11 +19,11 @@ class JSONEncoderOF10(json.JSONEncoder):
     Make casting from UBInt8, UBInt16, UBInt32, UBInt64 to int.
     """
 
-    def default(self, obj):  # pylint: disable=E0202,W0221
+    def default(self, o):
         """Make casting from UBInt8, UBInt16, UBInt32, UBInt64 to int."""
-        if isinstance(obj, UBIntBase):
-            return int(obj)
-        return json.JSONEncoder.default(self, obj)
+        if isinstance(o, UBIntBase):
+            return int(o)
+        return json.JSONEncoder.default(self, o)
 
 
 def update_flow_list(controller, switch):


### PR DESCRIPTION
- Ugraded core dev dependencies (they needed to be regenerated). It's related to https://github.com/kytos-ng/kytos/pull/284. 
- I've also upgraded `pylint` and fixed linter errors that showed up. 
- For now, `feature/upgrade_dependencies` kytos branch is pinned just so tests pass in the CI. I'll revert this after before this PR gets merged after review. 