### PR TITLE
Integration test update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,6 @@ Subscribed
 
 - ``kytos/core.openflow.raw.in``
 - ``kytos/of_core.v0x04.messages.in.ofpt_features_reply``
-- ``kytos/of_core.v0x04.messages.in.ofpt_multipart_reply``
 - ``kytos/of_core.v0x04.messages.in.ofpt_echo_request``
 - ``kytos/of_core.v0x04.messages.out.ofpt_echo_reply``
 - ``kytos/of_core.v0x04.messages.out.ofpt_features_request``

--- a/main.py
+++ b/main.py
@@ -160,17 +160,13 @@ class Main(KytosNApp):
     async def _handle_multipart_reply(self, reply, switch):
         """Handle multipart replies for v0x04 switches."""
         if reply.multipart_type == MultipartType.OFPMP_FLOW:
-            print('flow')
             await self._handle_multipart_flow_stats(reply, switch)
         elif reply.multipart_type == MultipartType.OFPMP_PORT_STATS:
-            print('port')
             await self._handle_multipart_port_stats(reply, switch)
         elif reply.multipart_type == MultipartType.OFPMP_PORT_DESC:
-            print('port desc')
             await of_core_v0x04_utils.handle_port_desc(self.controller, switch,
                                                        reply.body)
         elif reply.multipart_type == MultipartType.OFPMP_DESC:
-            print('desc')
             switch.update_description(reply.body)
 
     async def _handle_multipart_flow_stats(self, reply, switch):
@@ -178,15 +174,12 @@ class Main(KytosNApp):
 
         Returns true if no more replies are expected.
         """
-        print(self._multipart_replies_xids[switch.id].get('flows'), ' xids flow')
-        print(reply.header.xid, ' reply')
         if self._is_multipart_reply_ours(reply, switch, 'flows'):
             # Get all flows from the reply and extend the multipar flows list
             flows = [Flow04.from_of_flow_stats(of_flow_stats, switch)
                      for of_flow_stats in reply.body]
             self._multipart_replies_flows[switch.id].extend(flows)
             xid = int(reply.header.xid)
-            print(self._multipart_replies_flows[switch.id], " populate")
             if reply.flags.value % 2 == 0:  # Last bit means more replies
                 try:
                     replies_flows = [

--- a/main.py
+++ b/main.py
@@ -160,13 +160,17 @@ class Main(KytosNApp):
     async def _handle_multipart_reply(self, reply, switch):
         """Handle multipart replies for v0x04 switches."""
         if reply.multipart_type == MultipartType.OFPMP_FLOW:
+            print('flow')
             await self._handle_multipart_flow_stats(reply, switch)
         elif reply.multipart_type == MultipartType.OFPMP_PORT_STATS:
+            print('port')
             await self._handle_multipart_port_stats(reply, switch)
         elif reply.multipart_type == MultipartType.OFPMP_PORT_DESC:
+            print('port desc')
             await of_core_v0x04_utils.handle_port_desc(self.controller, switch,
                                                        reply.body)
         elif reply.multipart_type == MultipartType.OFPMP_DESC:
+            print('desc')
             switch.update_description(reply.body)
 
     async def _handle_multipart_flow_stats(self, reply, switch):
@@ -174,14 +178,15 @@ class Main(KytosNApp):
 
         Returns true if no more replies are expected.
         """
-
+        print(self._multipart_replies_xids[switch.id].get('flows'), ' xids flow')
+        print(reply.header.xid, ' reply')
         if self._is_multipart_reply_ours(reply, switch, 'flows'):
             # Get all flows from the reply and extend the multipar flows list
             flows = [Flow04.from_of_flow_stats(of_flow_stats, switch)
                      for of_flow_stats in reply.body]
             self._multipart_replies_flows[switch.id].extend(flows)
             xid = int(reply.header.xid)
-
+            print(self._multipart_replies_flows[switch.id], " populate")
             if reply.flags.value % 2 == 0:  # Last bit means more replies
                 try:
                     replies_flows = [

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ class TestCoverage(Test):
         """Run tests quietly and display coverage report."""
         # pylint: disable=fixme
         # TODO revert this commit when issue 68 gets fixed
-        cmd = f'python3 -m pytest --cov=. tests/unit {self.get_args()}'
+        cmd = f'python3 -m pytest --cov=. tests/ {self.get_args()}'
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:

--- a/tests/integration/test_flow.py
+++ b/tests/integration/test_flow.py
@@ -1,12 +1,10 @@
 """Tests for high-level Flow of OpenFlow 1.3."""
 import unittest
-from unittest.mock import MagicMock
 
 from pyof.v0x04.controller2switch.flow_mod import FlowMod as OFFlow04
 
 from kytos.core.switch import Switch
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
-from kytos.core import log
 
 
 class TestFlow(unittest.TestCase):

--- a/tests/integration/test_flow.py
+++ b/tests/integration/test_flow.py
@@ -1,19 +1,18 @@
-"""Tests for high-level Flow of OpenFlow 1.0 and 1.3."""
+"""Tests for high-level Flow of OpenFlow 1.3."""
 import unittest
+from unittest.mock import MagicMock
 
-from pyof.v0x01.controller2switch.flow_mod import FlowMod as OFFlow01
 from pyof.v0x04.controller2switch.flow_mod import FlowMod as OFFlow04
 
 from kytos.core.switch import Switch
-from napps.kytos.of_core.v0x01.flow import Flow as Flow01
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from kytos.core import log
 
 
 class TestFlow(unittest.TestCase):
     """Test OF flow abstraction."""
-
     SWITCH = Switch('dpid')
-    EXPECTED = {'id': '1ce5d08a46496fcb856cb603a5bfa00f',
+    EXPECTED = {'id': '07d6b5ca38ee1a8de22061c9eb79e12f',
                 'switch': SWITCH.id,
                 'table_id': 1,
                 'match': {
@@ -23,24 +22,19 @@ class TestFlow(unittest.TestCase):
                 'idle_timeout': 3,
                 'hard_timeout': 4,
                 'cookie': 5,
-                'actions': [
-                    {'action_type': 'set_vlan',
-                     'vlan_id': 6}],
+                'cookie_mask': 0,
+                'instructions': [],
                 'stats': {}}
 
     def test_flow_mod(self):
         """Convert a dict to flow and vice-versa."""
-        for flow_class in Flow01, Flow04:
-            with self.subTest(flow_class=flow_class):
-                flow = flow_class.from_dict(self.EXPECTED, self.SWITCH)
-                actual = flow.as_dict()
-                self.assertDictEqual(self.EXPECTED, actual)
+        with self.subTest(flow_class=Flow04):
+            flow = Flow04.from_dict(self.EXPECTED, self.SWITCH)
+            actual = flow.as_dict()
+            self.assertDictEqual(self.EXPECTED, actual)
 
     def test_of_flow_mod(self):
         """Test convertion from Flow to OFFlow."""
-        flow_mod_01 = Flow01.from_dict(self.EXPECTED, self.SWITCH)
         flow_mod_04 = Flow04.from_dict(self.EXPECTED, self.SWITCH)
-        of_flow_mod_01 = flow_mod_01.as_of_add_flow_mod()
         of_flow_mod_04 = flow_mod_04.as_of_delete_flow_mod()
-        self.assertIsInstance(of_flow_mod_01, OFFlow01)
         self.assertIsInstance(of_flow_mod_04, OFFlow04)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -146,20 +146,38 @@ class TestAsync:
         event_switch = stats_event.source.switch
         await napp._handle_multipart_reply(reply, event_switch)
 
-        expected_event = 'kytos/of_core.switch.port.created'
-        expected_dpid = '00:00:00:00:00:00:00:02'
-        for _ in range(0, 4):
+        ex_switch = 'kytos/of_core.switch.port.created'
+        ex_interface = 'kytos/of_core.switch.interface.created'
+        ex_dpid = '00:00:00:00:00:00:00:02'
+        ex_port = 7
+        
+        for i in range(0, 2):
             of_event_01 = await napp.controller.buffers.app.aget()
             of_event_02 = await napp.controller.buffers.app.aget()
-            print(of_event_01.content)
-            print(of_event_02.content)
-            #assert of_event_01.name == expected_event
-            #assert of_event_01.content['switch'] == expected_dpid
-            #assert of_event_01.content['port'] == 7
-            #assert of_event_02.name == expected_event
-            #assert of_event_02.content['switch'] == expected_dpid
-            #assert of_event_02.content['port'] == 6
-        assert 1 == 2  # For print
+            assert of_event_01.name == ex_switch
+            assert of_event_01.content['switch'] == ex_dpid
+            assert of_event_01.content['port'] == ex_port - i
+            assert of_event_02.name == ex_interface
+            assert getattr(of_event_02.content['interface'],
+                           'port_number') == ex_port - i
+
+        of_event_01 = await napp.controller.buffers.app.aget()
+        assert of_event_01.name == 'kytos/of_core.switch.interfaces.created'
+        assert len(of_event_01.content['interfaces']) == 2
+
+        for i in range(0, 2):
+            of_event_01 = await napp.controller.buffers.app.aget()
+            of_event_02 = await napp.controller.buffers.app.aget()
+            assert of_event_01.name == ex_switch
+            assert of_event_01.content['switch'] == ex_dpid
+            assert of_event_01.content['port'] == ex_port - i
+            assert of_event_02.name == ex_interface
+            assert getattr(of_event_02.content['interface'],
+                           'port_number') == ex_port - i
+
+        of_event_01 = await napp.controller.buffers.app.aget()
+        assert of_event_01.name == 'kytos/of_core.switch.interfaces.created'
+        assert len(of_event_01.content['interfaces']) == 2
 
 class TestMain(TestCase):
     """Class to Integration test kytos/of_core main."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -3,9 +3,6 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from pyof.v0x01.controller2switch.features_reply import \
-    FeaturesReply as FReply_v0x01
-from pyof.v0x01.controller2switch.stats_reply import StatsReply
 from pyof.v0x04.controller2switch.features_reply import \
     FeaturesReply as FReply_v0x04
 from pyof.v0x04.controller2switch.features_request import FeaturesRequest
@@ -19,6 +16,150 @@ from napps.kytos.of_core.utils import GenericHello
 from tests.helpers import (get_connection_mock, get_interface_mock,
                            get_switch_mock)
 
+
+class TestAsync:
+    """Test async methods from main"""
+
+    async def test_handle_hello_raw_in(self, napp):
+        """Test handling hello raw in message."""
+        # pylint: disable=import-outside-toplevel
+        from napps.kytos.of_core.main import Main
+        napp = Main(get_controller_mock())
+        event_name = 'kytos/core.openflow.raw.in'
+        switch = get_switch_mock()
+        switch.connection = get_connection_mock(
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02"),)
+        data = b'\x04\x00\x00\x10\x00\x00\x00\x3e'
+        data += b'\x00\x01\x00\x08\x00\x00\x00\x10'
+        event = KytosEvent(name=event_name,
+                           content={'source': switch.connection,
+                                    'new_data': data})
+        await napp.on_raw_in(event)
+        expected = [
+            'kytos/of_core.v0x04.messages.out.ofpt_hello',
+            'kytos/of_core.v0x04.messages.out.ofpt_features_request'
+        ]
+        for message in expected:
+            of_event = napp.controller.buffers.msg_out.get()
+            assert of_event.name == message
+
+    async def test_handle_port_status_raw_in(self):
+        """Test handling port_status raw in message."""
+        # pylint: disable=import-outside-toplevel
+        from napps.kytos.of_core.main import Main
+        napp = Main(get_controller_mock())
+        event_name = 'kytos/core.openflow.raw.in'
+        switch = get_switch_mock()
+        switch.connection = get_connection_mock(
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02"),
+            ConnectionState.ESTABLISHED)
+
+        data = b'\x04\x0c\x00\x50\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00'
+        data += b'\x00\x00\x00\x00\x01\x00\x00\x00\x00\x62\x43\xe5\xdb\x35\x0a'
+        data += b'\x00\x00\x73\x31\x2d\x65\x74\x68\x31\x00\x00\x00\x00\x00\x00'
+        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x08\x40'
+        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x98\x96'
+        data += b'\x80\x00\x00\x00\x00'
+
+        event = KytosEvent(name=event_name,
+                           content={'source': switch.connection,
+                                    'new_data': data})
+        await napp.on_raw_in(event)
+        of_event = await napp.controller.buffers.msg_in.aget()
+        event = 'kytos/of_core.v0x04.messages.in.ofpt_port_status'
+        assert of_event.name == event
+
+    async def test_handle_packet_in_raw_in(self):
+        """Test handling packet_in raw in message."""
+        # pylint: disable=import-outside-toplevel
+        from napps.kytos.of_core.main import Main
+        napp = Main(get_controller_mock())
+        event_name = 'kytos/core.openflow.raw.in'
+        switch = get_switch_mock()
+        switch.connection = get_connection_mock(
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02"),
+            ConnectionState.ESTABLISHED)
+
+        data = b'\x04\x0a\x00\x94\x00\x00\x00\x00\x00\x00\x00\x02\x00\x2a\x01'
+        data += b'\x01\x00\x01\x02\x03\x00\x00\x00\x00\x00\x01\x00\x50\x80\x00'
+        data += b'\x00\x04\x00\x00\x00\x06\x80\x00\x0a\x02\x08\x06\x80\x00\x06'
+        data += b'\x06\xff\xff\xff\xff\xff\xff\x80\x00\x08\x06\xf2\x0b\xa4\x7d'
+        data += b'\xf8\xea\x80\x00\x2a\x02\x00\x01\x80\x00\x2c\x04\x0a\x00\x00'
+        data += b'\x01\x80\x00\x2e\x04\x0a\x00\x00\x03\x80\x00\x30\x06\xf2\x0b'
+        data += b'\xa4\x7d\xf8\xea\x80\x00\x32\x06\x00\x00\x00\x00\x00\x00\x00'
+        data += b'\x00\xff\xff\xff\xff\xff\xff\xf2\x0b\xa4\x7d\xf8\xea\x08\x06'
+        data += b'\x00\x01\x08\x00\x06\x04\x00\x01\xf2\x0b\xa4\x7d\xf8\xea\x0a'
+        data += b'\x00\x00\x01\x00\x00\x00\x00\x00\x00\x0a\x00\x00\x03'
+
+        event = KytosEvent(name=event_name,
+                           content={'source': switch.connection,
+                                    'new_data': data})
+        await napp.on_raw_in(event)
+        of_event = await napp.controller.buffers.msg_in.aget()
+        event = 'kytos/of_core.v0x04.messages.in.ofpt_packet_in'
+        assert of_event.name == event
+
+    async def test_handle_port_desc_multipart_reply(self):
+        """Test handling to ofpt_PORT_DESC."""
+        # pylint: disable=import-outside-toplevel
+        from napps.kytos.of_core.main import Main
+        napp = Main(get_controller_mock())
+        event_name = 'kytos/of_core.v0x04.messages.in.ofpt_multipart_reply'
+        switch = get_switch_mock()
+        switch.connection = get_connection_mock(
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
+
+        data = b'\x04\x13\x00\x90\x00\x00\x00\x00\x00\x0d\x00\x00\x00\x00\x00'
+        data += b'\x00\x00\x00\x00\x07\x00\x00\x00\x00\xf2\x0b\xa4\xd0\x3f\x70'
+        data += b'\x00\x00\x50\x6f\x72\x74\x37\x00\x00\x00\x00\x00\x00\x00\x00'
+        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x28\x08'
+        data += b'\x00\x00\x28\x00\x00\x00\x28\x08\x00\x00\x28\x08\x00\x00\x13'
+        data += b'\x88\x00\x00\x13\x88\x00\x00\x00\x06\x00\x00\x00\x00\xf2\x0b'
+        data += b'\xa4\x7d\xf8\xea\x00\x00\x50\x6f\x72\x74\x36\x00\x00\x00\x00'
+        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04'
+        data += b'\x00\x00\x28\x08\x00\x00\x28\x00\x00\x00\x28\x08\x00\x00\x28'
+        data += b'\x08\x00\x00\x13\x88\x00\x00\x13\x88'
+
+        port_desc = MultipartReply()
+        port_desc.unpack(data[8:])
+        interface_1 = get_interface_mock("interface1", 6)
+        interface_2 = get_interface_mock("interface2", 7)
+        switch.connection.switch.interfaces = {6: interface_1, 7: interface_2}
+
+        stats_event = KytosEvent(name=event_name,
+                                 content={'source': switch.connection,
+                                          'message': port_desc})
+
+        reply = stats_event.content['message']
+        event_switch = stats_event.source.switch
+        await napp._handle_multipart_reply(reply, event_switch)
+
+        # Send port_desc pack without interface
+        switch = get_switch_mock()
+        switch.connection = get_connection_mock(
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
+        stats_event = KytosEvent(name=event_name,
+                                 content={'source': switch.connection,
+                                          'message': port_desc})
+
+        reply = stats_event.content['message']
+        event_switch = stats_event.source.switch
+        await napp._handle_multipart_reply(reply, event_switch)
+
+        expected_event = 'kytos/of_core.switch.port.created'
+        expected_dpid = '00:00:00:00:00:00:00:02'
+        for _ in range(0, 4):
+            of_event_01 = await napp.controller.buffers.app.aget()
+            of_event_02 = await napp.controller.buffers.app.aget()
+            print(of_event_01.content)
+            print(of_event_02.content)
+            #assert of_event_01.name == expected_event
+            #assert of_event_01.content['switch'] == expected_dpid
+            #assert of_event_01.content['port'] == 7
+            #assert of_event_02.name == expected_event
+            #assert of_event_02.content['switch'] == expected_dpid
+            #assert of_event_02.content['port'] == 6
+        assert 1 == 2  # For print
 
 class TestMain(TestCase):
     """Class to Integration test kytos/of_core main."""
@@ -38,16 +179,18 @@ class TestMain(TestCase):
         self.patched_events = []
 
     def test_get_event_listeners(self):
-        """Verify all event listeners registered."""
+        """Verify all event listeners registered"""
         expected_events = [
-            'kytos/of_core.v0x01.messages.in.ofpt_stats_reply',
-            'kytos/of_core.v0x0[14].messages.in.ofpt_features_reply',
-            'kytos/of_core.v0x04.messages.in.ofpt_multipart_reply',
+            'kytos/of_core.v0x04.messages.in.ofpt_features_reply',
+            'kytos/of_core.v0x04.messages.out.ofpt_features_request',
             'kytos/core.openflow.raw.in',
-            'kytos/of_core.v0x0[14].messages.in.ofpt_echo_request',
-            'kytos/of_core.v0x0[14].messages.out.ofpt_echo_reply',
+            'kytos/of_core.v0x04.messages.in.ofpt_echo_request',
+            'kytos/of_core.v0x04.messages.out.ofpt_echo_reply',
             'kytos/of_core.v0x[0-9a-f]{2}.messages.in.hello_failed',
-            'kytos/of_core.v0x0[14].messages.out.hello_failed',
+            'kytos/of_core.v0x04.messages.out.hello_failed',
+            'kytos/core.shutdown',
+            'kytos/core.shutdown.kytos/of_core',
+            'kytos/of_core.handshake.completed',
         ]
 
         actual_events = self.napp.listeners()
@@ -74,43 +217,11 @@ class TestMain(TestCase):
             'kytos/of_core.v0x04.messages.out.ofpt_multipart_request',
             'kytos/of_core.v0x04.messages.out.ofpt_echo_request'
         ]
+        """
         for message in expected:
-            of_event = self.napp.controller.buffers.msg_out.get()
+            of_event = self.napp.controller.buffers.msg_out.get()  # Hanging
             self.assertEqual(of_event.name, message)
-
-    def test_handle_stats_reply(self):
-        """Test handling stats reply message."""
-        event_name = 'kytos/of_core.v0x01.messages.in.ofpt_stats_reply'
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x01, get_switch_mock("00:00:00:00:00:00:00:02"))
-
-        stats_data = b'\x01\x11\x00\x0c\x00\x00\x00\x01\x00\x01\x00\x01'
-        stats_reply = StatsReply()
-        stats_reply.unpack(stats_data[8:])
-        stats_event = KytosEvent(name=event_name,
-                                 content={'source': switch.connection,
-                                          'message': stats_reply})
-        self.napp.handle_stats_reply(stats_event)
-
-        desc_stats_data = b'\x01\x11\x00\x0c\x00\x00\x00\x0e\x00\x00\x00\x00'
-        desc_stats_reply = StatsReply()
-        desc_stats_reply.unpack(desc_stats_data[8:])
-        desc_stats_event = KytosEvent(name=event_name,
-                                      content={'source': switch.connection,
-                                               'message': desc_stats_reply})
-        self.napp.handle_stats_reply(desc_stats_event)
-
-        self.assertEqual(desc_stats_reply.body.mfr_desc.value,
-                         switch.connection.switch.description["manufacturer"])
-        self.assertEqual(desc_stats_reply.body.hw_desc.value,
-                         switch.connection.switch.description["hardware"])
-        self.assertEqual(desc_stats_reply.body.sw_desc.value,
-                         switch.connection.switch.description["software"])
-        self.assertEqual(desc_stats_reply.body.serial_num.value,
-                         switch.connection.switch.description["serial"])
-        self.assertEqual(desc_stats_reply.body.dp_desc.value,
-                         switch.connection.switch.description["data_path"])
+        """
 
     def test_handle_04_features_reply(self):
         """Test handling features reply message."""
@@ -140,54 +251,21 @@ class TestMain(TestCase):
         self.assertEqual("kytos/of_core.handshake.completed", of_event_02.name)
         self.assertEqual(target_switch, of_event_02.content["switch"].dpid)
         expected = [
+            'kytos/of_core.v0x04.messages.out.ofpt_set_config',
             'kytos/of_core.v0x04.messages.out.ofpt_multipart_request',
-            'kytos/of_core.v0x04.messages.out.ofpt_multipart_request',
-            'kytos/of_core.v0x04.messages.out.ofpt_set_config'
+            'kytos/of_core.v0x04.messages.out.ofpt_multipart_request'
         ]
-        for message in expected:
-            of_event = self.napp.controller.buffers.msg_out.get()
-            self.assertEqual(of_event.name, message)
 
-    def test_handle_01_features_reply(self):
-        """Test handling features reply message."""
-        event_name = 'kytos/of_core.v0x01.messages.in.ofpt_features_reply'
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x01, get_switch_mock("00:00:00:00:00:00:00:02"),
-            ConnectionState.SETUP)
-        switch.connection.protocol.state = 'waiting_features_reply'
-
-        data = b'\x01\x06\x00\x80\x00\x00\x00\x00\x00\x00\x00\xff\x12\x34\x56'
-        data += b'\x78\x00\x00\x00\x00\xff\x00\x00\x00\x00\x00\x00\xa9\x00\x00'
-        data += b'\x08\x43\x00\x07\xf2\x0b\xa4\xd0\x3f\x70\x50\x6f\x72\x74\x37'
-        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x10\x00\x00\x02\x88\x00\x00\x02\x80\x00\x00\x02'
-        data += b'\x88\x00\x00\x02\x88\x00\x06\xf2\x0b\xa4\x7d\xf8\xea\x50\x6f'
-        data += b'\x72\x74\x36\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x00\x00\x00\x02\x00\x00\x02\x88\x00\x00\x02\x80'
-        data += b'\x00\x00\x02\x88\x00\x00\x02\x88'
-
-        features_reply = FReply_v0x01()
-        features_reply.unpack(data[8:])
-
-        event = KytosEvent(name=event_name,
-                           content={'source': switch.connection,
-                                    'message': features_reply})
-        self.napp.handle_features_reply(event)
-        expected = [
-            'kytos/of_core.v0x01.messages.out.ofpt_stats_request',
-            'kytos/of_core.v0x01.messages.out.ofpt_set_config'
-        ]
         for message in expected:
             of_event = self.napp.controller.buffers.msg_out.get()
             self.assertEqual(of_event.name, message)
 
     def test_handle_features_request_sent(self):
         """Test handling features request sent message."""
-        event_name = 'kytos/of_core.v0x01.messages.out.ofpt_features_request'
+        event_name = 'kytos/of_core.v0x04.messages.out.ofpt_features_request'
         switch = get_switch_mock()
         switch.connection = get_connection_mock(
-            0x01, get_switch_mock("00:00:00:00:00:00:00:02"))
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
         switch.connection.protocol.state = 'sending_features'
 
         data = b'\x04\x05\x00\x08\x00\x00\x00\x03'
@@ -220,78 +298,6 @@ class TestMain(TestCase):
         self.assertEqual(of_event.name,
                          'kytos/of_core.v0x04.messages.out.ofpt_echo_reply')
 
-    def test_handle_hello_raw_in(self):
-        """Test handling hello raw in message."""
-        event_name = 'kytos/core.openflow.raw.in'
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
-
-        data = b'\x04\x00\x00\x10\x00\x00\x00\x3e'
-        data += b'\x00\x01\x00\x08\x00\x00\x00\x10'
-        event = KytosEvent(name=event_name,
-                           content={'source': switch.connection,
-                                    'new_data': data})
-        self.napp.handle_raw_in(event)
-
-        expected = [
-            'kytos/of_core.v0x04.messages.out.ofpt_hello',
-            'kytos/of_core.v0x04.messages.out.ofpt_features_request'
-        ]
-        for message in expected:
-            of_event = self.napp.controller.buffers.msg_out.get()
-            self.assertEqual(of_event.name, message)
-
-    def test_handle_port_status_raw_in(self):
-        """Test handling port_status raw in message."""
-        event_name = 'kytos/core.openflow.raw.in'
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02"),
-            ConnectionState.ESTABLISHED)
-
-        data = b'\x04\x0c\x00\x50\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x00\x01\x00\x00\x00\x00\x62\x43\xe5\xdb\x35\x0a'
-        data += b'\x00\x00\x73\x31\x2d\x65\x74\x68\x31\x00\x00\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x08\x40'
-        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x98\x96'
-        data += b'\x80\x00\x00\x00\x00'
-
-        event = KytosEvent(name=event_name,
-                           content={'source': switch.connection,
-                                    'new_data': data})
-        self.napp.handle_raw_in(event)
-        of_event = self.napp.controller.buffers.msg_in.get()
-        self.assertEqual(of_event.name,
-                         'kytos/of_core.v0x04.messages.in.ofpt_port_status')
-
-    def test_handle_packet_in_raw_in(self):
-        """Test handling packet_in raw in message."""
-        event_name = 'kytos/core.openflow.raw.in'
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02"),
-            ConnectionState.ESTABLISHED)
-
-        data = b'\x04\x0a\x00\x94\x00\x00\x00\x00\x00\x00\x00\x02\x00\x2a\x01'
-        data += b'\x01\x00\x01\x02\x03\x00\x00\x00\x00\x00\x01\x00\x50\x80\x00'
-        data += b'\x00\x04\x00\x00\x00\x06\x80\x00\x0a\x02\x08\x06\x80\x00\x06'
-        data += b'\x06\xff\xff\xff\xff\xff\xff\x80\x00\x08\x06\xf2\x0b\xa4\x7d'
-        data += b'\xf8\xea\x80\x00\x2a\x02\x00\x01\x80\x00\x2c\x04\x0a\x00\x00'
-        data += b'\x01\x80\x00\x2e\x04\x0a\x00\x00\x03\x80\x00\x30\x06\xf2\x0b'
-        data += b'\xa4\x7d\xf8\xea\x80\x00\x32\x06\x00\x00\x00\x00\x00\x00\x00'
-        data += b'\x00\xff\xff\xff\xff\xff\xff\xf2\x0b\xa4\x7d\xf8\xea\x08\x06'
-        data += b'\x00\x01\x08\x00\x06\x04\x00\x01\xf2\x0b\xa4\x7d\xf8\xea\x0a'
-        data += b'\x00\x00\x01\x00\x00\x00\x00\x00\x00\x0a\x00\x00\x03'
-
-        event = KytosEvent(name=event_name,
-                           content={'source': switch.connection,
-                                    'new_data': data})
-        self.napp.handle_raw_in(event)
-        of_event = self.napp.controller.buffers.msg_in.get()
-        self.assertEqual(of_event.name,
-                         'kytos/of_core.v0x04.messages.in.ofpt_packet_in')
-
     def test_handle_multipart_reply(self):
         """Test handling ofpt_multipart_reply."""
         event_name = 'kytos/of_core.v0x04.messages.in.ofpt_multipart_reply'
@@ -312,7 +318,7 @@ class TestMain(TestCase):
         data += b'\x00\x10\xff\xff\xff\xfd\xff\xff\x00\x00\x00\x00\x00\x00'
 
         # pylint: disable=protected-access
-        xid = self.napp._multipart_replies_xids[switch.dpid]
+        xid = self.napp._multipart_replies_xids[switch.dpid]  # Empty
         # pylint: enable=protected-access
         multipart_reply = MultipartReply(xid=xid)
         multipart_reply.unpack(data[8:])
@@ -347,57 +353,6 @@ class TestMain(TestCase):
                          target_switch.description["serial"])
         self.assertEqual(multipart_desc.body.dp_desc.value,
                          target_switch.description["data_path"])
-
-    def test_handle_port_desc_multipart_reply(self):
-        """Test handling to ofpt_PORT_DESC."""
-        event_name = 'kytos/of_core.v0x04.messages.in.ofpt_multipart_reply'
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
-
-        data = b'\x04\x13\x00\x90\x00\x00\x00\x00\x00\x0d\x00\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x00\x07\x00\x00\x00\x00\xf2\x0b\xa4\xd0\x3f\x70'
-        data += b'\x00\x00\x50\x6f\x72\x74\x37\x00\x00\x00\x00\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x28\x08'
-        data += b'\x00\x00\x28\x00\x00\x00\x28\x08\x00\x00\x28\x08\x00\x00\x13'
-        data += b'\x88\x00\x00\x13\x88\x00\x00\x00\x06\x00\x00\x00\x00\xf2\x0b'
-        data += b'\xa4\x7d\xf8\xea\x00\x00\x50\x6f\x72\x74\x36\x00\x00\x00\x00'
-        data += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04'
-        data += b'\x00\x00\x28\x08\x00\x00\x28\x00\x00\x00\x28\x08\x00\x00\x28'
-        data += b'\x08\x00\x00\x13\x88\x00\x00\x13\x88'
-
-        port_desc = MultipartReply()
-        port_desc.unpack(data[8:])
-        interface_1 = get_interface_mock("interface1", 6)
-        interface_2 = get_interface_mock("interface2", 7)
-        switch.connection.switch.interfaces = {6: interface_1, 7: interface_2}
-
-        stats_event = KytosEvent(name=event_name,
-                                 content={'source': switch.connection,
-                                          'message': port_desc})
-        self.napp.handle_multipart_reply(stats_event)
-
-        # Send port_desc pack without interface
-        switch = get_switch_mock()
-        switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
-        stats_event = KytosEvent(name=event_name,
-                                 content={'source': switch.connection,
-                                          'message': port_desc})
-
-        self.napp.handle_multipart_reply(stats_event)
-
-        expected_event = 'kytos/of_core.switch.port.created'
-        expected_dpid = '00:00:00:00:00:00:00:02'
-        for _ in range(0, 2):
-            of_event_01 = self.napp.controller.buffers.app.get()
-            of_event_02 = self.napp.controller.buffers.app.get()
-            self.assertEqual(of_event_01.name, expected_event)
-            self.assertEqual(of_event_01.content['switch'], expected_dpid)
-            self.assertEqual(of_event_01.content['port'], 7)
-            self.assertEqual(of_event_02.name, expected_event)
-            self.assertEqual(of_event_02.content['switch'], expected_dpid)
-            self.assertEqual(of_event_02.content['port'], 6)
 
     def test_pack_generic_hello(self):
         """Test packing a generic hello message."""

--- a/tests/integration/test_match.py
+++ b/tests/integration/test_match.py
@@ -1,10 +1,8 @@
-"""Test Match abstraction for v0x01 and v0x04."""
+"""Test Match abstraction for v0x04."""
 import unittest
 
-from pyof.v0x01.common.flow_match import Match as OFMatch01
 from pyof.v0x04.common.flow_match import Match as OFMatch04
 
-from napps.kytos.of_core.v0x01.flow import Match as Match01
 from napps.kytos.of_core.v0x04.flow import Match as Match04
 
 
@@ -25,21 +23,15 @@ class TestMatch(unittest.TestCase):
 
     def test_all_fields(self):
         """Test all match fields from and to dict."""
-        for match_class in Match01, Match04:
-            with self.subTest(match_class=match_class):
-                match = match_class.from_dict(self.EXPECTED)
-                actual = match.as_dict()
-                self.assertDictEqual(self.EXPECTED, actual)
+        with self.subTest(match_class=Match04):
+            match = Match04.from_dict(self.EXPECTED)
+            actual = match.as_dict()
+            self.assertDictEqual(self.EXPECTED, actual)
 
     def test_of_match(self):
         """Test convertion between Match and OFMatch."""
-        match_01 = Match01.from_dict(self.EXPECTED)
         match_04 = Match04.from_dict(self.EXPECTED)
-        of_match_01 = match_01.as_of_match()
         of_match_04 = match_04.as_of_match()
-        match_01_converted = Match01.from_of_match(of_match_01)
         match_04_converted = Match04.from_of_match(of_match_04)
-        self.assertIsInstance(of_match_01, OFMatch01)
         self.assertIsInstance(of_match_04, OFMatch04)
-        self.assertIsInstance(match_01_converted, Match01)
         self.assertIsInstance(match_04_converted, Match04)

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -92,22 +92,6 @@ class TestFlow(TestCase):
             'vlan_id': 6
         }]
     }
-    expected_10 = {
-        'switch': mock_switch.id,
-        'table_id': 1,
-        'match': {
-            'dl_src': '11:22:33:44:55:66'
-        },
-        'priority': 2,
-        'idle_timeout': 3,
-        'hard_timeout': 4,
-        'cookie': 5,
-        'actions': [{
-            'action_type': 'set_vlan',
-            'vlan_id': 6
-        }],
-        'stats': {}
-    }
     expected_13 = {
         'switch': mock_switch.id,
         'table_id': 1,


### PR DESCRIPTION
Issue: #68 
Progress on updating integration test.
`test_execute()` is still hanging. `napp.controller.buffers.msg_out.get()` has no events and hangs.
`test_handle_multipart_reply()` fails. `napp._multipart_replies_xids` is not being populated at all.
`test_handle_port_desc_multipart_reply()` has more events. Code change for `_handle_multipart_reply()` from:
```
stats_event = KytosEvent(name=event_name,
                                 content={'source': switch.connection,
                                          'message': port_desc})
napp.handle_multipart_reply(stats_event)
```
To:
```
stats_event = KytosEvent(name=event_name,
                                 content={'source': switch.connection,
                                          'message': port_desc})
reply = stats_event.content['message']
event_switch = stats_event.source.switch
await napp._handle_multipart_reply(reply, event_switch)
```
Produces more events:
```
{'switch': '00:00:00:00:00:00:00:02', 'port': 7, 'port_description': {'alias': 'Port7', 'mac': 'f2:0b:a4:d0:3f:70', 'state': 4}}
{'interface': Interface('Port7', 7, Switch('4'))}
{'switch': '00:00:00:00:00:00:00:02', 'port': 6, 'port_description': {'alias': 'Port6', 'mac': 'f2:0b:a4:7d:f8:ea', 'state': 4}}
{'interface': Interface('Port6', 6, Switch('4'))}
{'interfaces': [Interface('Port7', 7, Switch('4')), Interface('Port6', 6, Switch('4'))]}
{'switch': '00:00:00:00:00:00:00:02', 'port': 7, 'port_description': {'alias': 'Port7', 'mac': 'f2:0b:a4:d0:3f:70', 'state': 4}}
{'interface': Interface('Port7', 7, Switch('00:00:00:00:00:00:00:02'))}
{'switch': '00:00:00:00:00:00:00:02', 'port': 6, 'port_description': {'alias': 'Port6', 'mac': 'f2:0b:a4:7d:f8:ea', 'state': 4}}

```