### PR TITLE
[Fix] Support ActionExperimenter sub classes to be deserialized from bytes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Removed
 
 Fixed
 =====
+- Augmented ``InstructionAction.from_of_instruction`` to support deserializing ActionExperimenter from ``FlowStats`` entries.
 
 Security
 ========

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -1,8 +1,12 @@
 """Test Action abstraction for v0x04."""
+from unittest.mock import MagicMock
+
 import pytest
 from pyof.foundation.basic_types import UBInt32
 
 from napps.kytos.of_core.v0x04.flow import Action as Action04
+
+# pylint: disable=protected-access,unnecessary-lambda-assignment
 
 
 @pytest.mark.parametrize(
@@ -50,3 +54,19 @@ def test_all_actions(action_class, action_dict):
     of_action = action.as_of_action()
     assert action_dict == actual
     assert action_dict == action_class.from_of_action(of_action).as_dict()
+
+
+def test_add_action_class():
+    """Test add_action_class."""
+    name, new_class = "some_class", MagicMock()
+    Action04.add_action_class(name, new_class)
+    assert Action04._action_class[name] == new_class
+
+
+def test_add_experimenter_classes():
+    """Test add_experimenter_classes."""
+    resp = MagicMock()
+    experimenter, func = 0xff000002, lambda body: resp
+    Action04.add_experimenter_classes(experimenter, func)
+    assert Action04._experimenter_classes[experimenter] == func
+    assert Action04.get_experimenter_class(experimenter, b'\xff') == resp


### PR DESCRIPTION
Fixes #87 

- Augmented ``InstructionAction.from_of_instruction`` to support deserializing ActionExperimenter from ``FlowStats`` entries.

NApps who register `ActionExperimenter` experimenter classes are supposed to also register the deserialization accordingly.

I'll post the local tests on https://github.com/kytos-ng/flow_stats/issues/43