### PR TITLE
[Fix] `OFPPS_LIVE` is now considered when handling port description and port status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Removed
 Fixed
 =====
 - Augmented ``InstructionAction.from_of_instruction`` to support deserializing ActionExperimenter from ``FlowStats`` entries.
+- ``OFPPS_LIVE`` is now considered when handling port description and port status
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from napps.kytos.of_core.utils import (GenericHello, NegotiationException,
                                        of_slicer)
 from napps.kytos.of_core.v0x04 import utils as of_core_v0x04_utils
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from napps.kytos.of_core.v0x04.utils import try_to_activate_interface
 
 
 class Main(KytosNApp):
@@ -589,6 +590,7 @@ class Main(KytosNApp):
                                   state=port.state.value,
                                   features=port.curr)
             source.switch.update_interface(interface)
+            try_to_activate_interface(interface, port)
 
         elif reason == 'OFPPR_MODIFY':
             status = 'modified'
@@ -611,6 +613,7 @@ class Main(KytosNApp):
                                       state=port.state.value,
                                       features=port.curr)
             source.switch.update_interface(interface)
+            try_to_activate_interface(interface, port)
             self._send_specific_port_mod(port, interface, current_status)
 
         elif reason == 'OFPPR_DELETE':

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -1,6 +1,6 @@
 """Utilities module for of_core OpenFlow v0x04 operations."""
 from pyof.v0x04.common.action import ControllerMaxLen
-from pyof.v0x04.common.port import PortConfig
+from pyof.v0x04.common.port import PortConfig, PortNo, PortState
 from pyof.v0x04.controller2switch.common import ConfigFlag, MultipartType
 from pyof.v0x04.controller2switch.multipart_request import (FlowStatsRequest,
                                                             MultipartRequest,
@@ -11,6 +11,18 @@ from pyof.v0x04.symmetric.hello import Hello
 
 from kytos.core.events import KytosEvent
 from napps.kytos.of_core.utils import aemit_message_out, emit_message_out
+
+
+def try_to_activate_interface(interface, port):
+    """Try activate or deactivate an interface given a port state."""
+    if any((
+        port.state.value == PortState.OFPPS_LIVE,
+        port.port_no.value == PortNo.OFPP_LOCAL.value
+    )):
+        interface.activate()
+    else:
+        interface.deactivate()
+    return interface
 
 
 def update_flow_list(controller, switch):
@@ -115,6 +127,7 @@ async def handle_port_desc(controller, switch, port_list):
                         features=port.curr,
                         config=config,
                         speed=port.curr_speed.value)
+        try_to_activate_interface(interface, port)
         interfaces.append(interface)
 
         event_name = 'kytos/of_core.switch.interface.created'


### PR DESCRIPTION
Fix #89 

- ``OFPPS_LIVE`` is now considered when handling port description and port status

## Local tests

I've explored it with OvS and NoviFlow switches at AmLight to make sure that ``OFPPS_LIVE`` on NoviFlow OpenFlow implementation would also behave correctly:

```
# show status port portno all
     port admin link description       port admin link description
     ---- ----- ---- -------------     ---- ----- ---- -------------
     1    up    up   Novi05-1          19   up    up   loop-20
     2    up    up   Novi02-2          20   up    up   loop-19
     3    down  down                   21   up    down
     4    down  down                   22   up    down
     5    up    down                   23   up    up   INT01-enp33s0
     6    up    down                   24   up    down
     7    up    down                   25   up    down
     8    up    down                   26   up    down
     9    up    down                   27   up    down
     10   up    down                   28   up    down
     11   up    down Novi06-11         29   up    down
     12   up    down                   30   up    down
     13   up    down                   31   up    down
     14   up    down                   32   up    down
     15   up    up   INT02             121  up    down
     16   up    up   INT01             221  up    down
     17   up    up   loop-18           321  up    down
     18   up    up   loop-17
```     

```
❯ curl -s http://127.0.0.1:8181/api/kytos/topology/v3/interfaces | jq '.interfaces[] | .n
ame + " " +  (.active|tostring)'
"novi_port_1 true"
"novi_port_2 true"
"novi_port_3 false"
"novi_port_4 false"
"novi_port_5 false"
"novi_port_6 false"
"novi_port_7 false"
"novi_port_8 false"
"novi_port_9 false"
"novi_port_10 false"
"novi_port_11 false"
"novi_port_12 false"
"novi_port_13 false"
"novi_port_14 false"
"novi_port_15 true"
"novi_port_16 true"
"novi_port_17 true"
"novi_port_18 true"
"novi_port_19 true"
"novi_port_20 true"
"novi_port_21 false"
"novi_port_22 false"
"novi_port_23 true"
"novi_port_24 false"
"novi_port_25 false"
"novi_port_26 false"
"novi_port_27 false"
"novi_port_28 false"
"novi_port_29 false"
"novi_port_30 false"
"novi_port_31 false"
"novi_port_32 false"
"novi_port_121 false"
"novi_port_221 false"
"novi_port_321 false"
"local true"
```

Without the fix, interfaces that are initially shut down before the handshake would be set as active

```
❯ curl -s http://127.0.0.1:8181/api/kytos/topology/v3/interfaces | jq '.interfaces[] | .n
ame + " " +  (.active|tostring)'
"novi_port_1 true"
"novi_port_2 true"
"novi_port_3 true"
"novi_port_4 true"
"novi_port_5 true"
"novi_port_6 true"
"novi_port_7 true"
"novi_port_8 true"
"novi_port_9 true"
"novi_port_10 true"
"novi_port_11 true"
"novi_port_12 true"
"novi_port_13 true"
"novi_port_14 true"
"novi_port_15 true"
"novi_port_16 true"
"novi_port_17 true"
"novi_port_18 true"
"novi_port_19 true"
"novi_port_20 true"
"novi_port_21 true"
"novi_port_22 true"
"novi_port_23 true"
"novi_port_24 true"
"novi_port_25 true"
"novi_port_26 true"
"novi_port_27 true"
"novi_port_28 true"
"novi_port_29 true"
"novi_port_30 true"
"novi_port_31 true"
"novi_port_32 true"
"novi_port_121 true"
"novi_port_221 true"
"novi_port_321 true"
"local true"
```
