### PR TITLE
[Fix] Reset multipart replies on connection lost and OF connection errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Removed
 Fixed
 =====
 - Augmented ``InstructionAction.from_of_instruction`` to support deserializing ActionExperimenter from ``FlowStats`` entries.
+- Subscribed to ``.*.connection.lost`` and ``kytos/core.openflow.connection.error`` to be able to reset multipart replies
 
 Security
 ========


### PR DESCRIPTION
Closes #91 

### Summary

- See updated changelog file
- I ended up using async handlers to avoid preemption and keep it lightweight (and aligned with other handlers)

### Local Tests

I explored locally simulating both events, and I temporarily added a log entry (`popping multipart replies for ...`):

- Switch reconnecting, once the connection was lost, it popped the multipart replies accordingly:

```
kytos $> 2022-12-08 12:31:01,552 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:57834. Reason: Request closed by client
2022-12-08 12:31:01,553 - INFO [kytos.napps.kytos/of_core] (MainThread) popping multipart replies for Switch('00:00:00:00:00:00:00:01')
2022-12-08 12:31:03,077 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:35414
2022-12-08 12:31:03,406 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_5) Connection ('127.0.0.1', 35414), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
```

- Simulated socket errors and `kytos/core.openflow.connection.error`, the multipart replies were popped accordingly:



```

kytos $> 2022-12-08 12:43:06,375 - INFO [kytos.napps.kytos/flow_manager] (Thread-92) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'f
lows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-12-08 12:43:06,381 - INFO [kytos.napps.kytos/flow_manager] (Thread-93) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: True, flows_dict: {'flows': [{'
table_id': 0, 'match': {'dl_src': 'ee:ee:ee:ee:ee:02'}, 'priority': 50000, 'actions': [{'action_type': 'output', 'port': 4294967293}], 'cookie': 12393906174523604993}, {'table_id': 0, '
match': {'dl_src': 'ee:ee:ee:ee:ee:03'}, 'priority': 50000, 'actions': [{'action_type': 'output', 'port': 4294967293}], 'cookie': 12393906174523604993}], 'force': True}
2022-12-08 12:43:06,401 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2022-12-08 12:43:06,403 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2022-12-08 12:43:06,404 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2022-12-08 12:43:06,407 - INFO [kytos.napps.kytos/of_core] (MainThread) popping multipart replies for Switch('00:00:00:00:00:00:00:01')
2022-12-08 12:43:06,407 - INFO [kytos.napps.kytos/of_core] (MainThread) popping multipart replies for Switch('00:00:00:00:00:00:00:01')
2022-12-08 12:43:06,407 - INFO [kytos.napps.kytos/of_core] (MainThread) popping multipart replies for Switch('00:00:00:00:00:00:00:01')
kytos $> 2022-12-08 12:43:07,340 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:47244
kytos $> 2022-12-08 12:43:07,842 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:47256
2022-12-08 12:43:07,857 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_1) Connection ('127.0.0.1', 47244), Switch 00:00:00:00:00:00:00:02: OPENFLOW HANDSHAKE COMPLETE
kytos $> 2022-12-08 12:43:07,895 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_1) Connection ('127.0.0.1', 47256), Switch 00:00:00:00:00:00:00:03: OPENFLOW HANDSHAKE COMPLETE

```

I'll also leave an e2e execution on this branch, I'll post the results here later.