### PR TITLE
Improve log message for PortStatus events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 - Augmented ``InstructionAction.from_of_instruction`` to support deserializing ActionExperimenter from ``FlowStats`` entries.
 - ``OFPPS_LIVE`` is now considered when handling port description and port status
 - Subscribed to ``.*.connection.lost`` and ``kytos/core.openflow.connection.error`` to be able to reset multipart replies
+- Improved log message for PortStatus events
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -644,7 +644,9 @@ class Main(KytosNApp):
         event = KytosEvent(name=event_name, content=content)
         self.controller.buffers.app.put(event)
 
-        state_desc = {v:k for k,v in PortState._enum.items()}
+        # pylint: disable=protected-access
+        state_desc = {v: k for k, v in PortState._enum.items()}
+        # pylint: enable=protected-access
         state = state_desc.get(port.state.value, port.state.value)
         msg = 'PortStatus %s interface %s:%s state %s'
         log.info(msg, status, source.switch.id, port_no, state)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from pyof.foundation.exceptions import UnpackException
 from pyof.foundation.network_types import Ethernet, EtherType
 from pyof.utils import PYOF_VERSION_LIBS, unpack
 from pyof.v0x04.common.header import Type
+from pyof.v0x04.common.port import PortState
 from pyof.v0x04.controller2switch.common import MultipartType
 
 from kytos.core import KytosEvent, KytosNApp, log
@@ -616,9 +617,6 @@ class Main(KytosNApp):
             interface = source.switch.get_interface_by_port_no(port_no)
             current_status = None
             if interface:
-                dpid = interface.switch.dpid
-                port_number = interface.port_number
-                log.info(f"Modified {interface} {dpid}:{port_number}")
                 current_status = interface.state
                 interface.state = port.state.value
                 interface.name = port.name.value
@@ -646,8 +644,10 @@ class Main(KytosNApp):
         event = KytosEvent(name=event_name, content=content)
         self.controller.buffers.app.put(event)
 
-        msg = 'The port %s from switch %s was %s.'
-        log.debug(msg, port_status.desc.port_no, source.switch.id, status)
+        state_desc = {v:k for k,v in PortState._enum.items()}
+        state = state_desc.get(port.state.value, port.state.value)
+        msg = 'PortStatus %s interface %s:%s state %s'
+        log.info(msg, status, source.switch.id, port_no, state)
 
 
 def _get_version_from_bitmask(message_versions):


### PR DESCRIPTION
Fixes #7 

### Description of the change

This PR improves the logging message sent upon receiving a PortStatus OF message to help the network operator understand the network's state from the log messages (very useful for troubleshooting activities).

Before this PR, the only message that was being recorded at the logs were `Modified {interface} {dpid}:{port_number}`: no info about the new state and no info when other states were being recorded.

### Local tests

Running Kytos with this PR and simulating a link failure and recovery gives the following log messages:

```
Jan 12 17:57:41 4919fb6963ef kytos.napps.kytos/of_core:INFO main:652:  PortStatus modified interface 00:00:00:00:00:00:00:12:1 state 0
Jan 12 17:57:41 4919fb6963ef kytos.napps.kytos/of_core:INFO main:652:  PortStatus modified interface 00:00:00:00:00:00:00:12:1 state OFPPS_LINK_DOWN
Jan 12 17:57:41 4919fb6963ef kytos.napps.kytos/of_core:INFO main:652:  PortStatus modified interface 00:00:00:00:00:00:00:11:1 state 0
Jan 12 17:57:41 4919fb6963ef kytos.napps.kytos/of_core:INFO main:652:  PortStatus modified interface 00:00:00:00:00:00:00:11:1 state OFPPS_LINK_DOWN
Jan 12 17:57:51 4919fb6963ef kytos.napps.kytos/of_core:INFO main:652:  PortStatus modified interface 00:00:00:00:00:00:00:12:1 state OFPPS_LIVE
Jan 12 17:57:51 4919fb6963ef kytos.napps.kytos/of_core:INFO main:652:  PortStatus modified interface 00:00:00:00:00:00:00:11:1 state OFPPS_LIVE
```