### PR TITLE
Added a way to handle `4096/4096` and 0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Changed
 =======
-- ``MatchDLVLAN`` can handle values such as ``4096/4096`` and 0
+- ``MatchDLVLAN`` can handle values such as ``"4096/4096"`` and 0
 
 
 [2022.3.1] - 2023-02-23

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- ``MatchDLVLAN`` can handle values such as ``4096/4096`` and 0
+
+
 [2022.3.1] - 2023-02-23
 ***********************
 

--- a/tests/integration/v0x04/test_match.py
+++ b/tests/integration/v0x04/test_match.py
@@ -20,3 +20,17 @@ class TestMatch(unittest.TestCase):
         of_tlv = expected.as_of_tlv()
         actual = MatchDLVLAN.from_of_tlv(of_tlv)
         self.assertEqual(expected, actual)
+
+    def test_dl_vlan_mask_pyof(self):
+        """Convert to and from pyog OxmTLV with mask"""
+        expected = MatchDLVLAN("4096/4096")
+        of_tlv = expected.as_of_tlv()
+        actual = MatchDLVLAN.from_of_tlv(of_tlv)
+        self.assertEqual(expected, actual)
+
+    def test_dl_vlan_zero_pyof(self):
+        """Convert to and from pyog OxmTLV with 0"""
+        expected = MatchDLVLAN(0)
+        of_tlv = expected.as_of_tlv()
+        actual = MatchDLVLAN.from_of_tlv(of_tlv)
+        self.assertEqual(expected, actual)

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -39,16 +39,13 @@ class MatchDLVLAN(MatchField):
             value = int(self.value)
             mask = None
             oxm_hasmask = False
-            value = value | VlanId.OFPVID_PRESENT
         except ValueError:
-            try:
-                value, mask = map(int, self.value.split('/'))
-                oxm_hasmask = True
-                value = value | VlanId.OFPVID_PRESENT
-            except ValueError:
-                mask = None
-                oxm_hasmask = False
-                value = VlanId.OFPVID_NONE
+            value, mask = map(int, self.value.split('/'))
+            oxm_hasmask = True
+        if value == 0:
+            value = VlanId.OFPVID_NONE
+        else:
+            value = value | VlanId.OFPVID_PRESENT
         value_bytes = value.to_bytes(2, 'big')
         if mask:
             mask = mask | VlanId.OFPVID_PRESENT

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -39,10 +39,16 @@ class MatchDLVLAN(MatchField):
             value = int(self.value)
             mask = None
             oxm_hasmask = False
+            value = value | VlanId.OFPVID_PRESENT
         except ValueError:
-            value, mask = map(int, self.value.split('/'))
-            oxm_hasmask = True
-        value = value | VlanId.OFPVID_PRESENT
+            try:
+                value, mask = map(int, self.value.split('/'))
+                oxm_hasmask = True
+                value = value | VlanId.OFPVID_PRESENT
+            except ValueError:
+                mask = None
+                oxm_hasmask = False
+                value = VlanId.OFPVID_NONE
         value_bytes = value.to_bytes(2, 'big')
         if mask:
             mask = mask | VlanId.OFPVID_PRESENT

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -37,14 +37,14 @@ class MatchDLVLAN(MatchField):
         """Return a pyof OXM TLV instance."""
         try:
             value = int(self.value)
-            value = value | VlanId.OFPVID_PRESENT
-            if value == 0:
-                value = VlanId.OFPVID_NONE
             mask = None
             oxm_hasmask = False
         except ValueError:
             value, mask = map(int, self.value.split('/'))
             oxm_hasmask = True
+        if value == 0:
+            value = VlanId.OFPVID_NONE
+        else:
             value = value | VlanId.OFPVID_PRESENT
         value_bytes = value.to_bytes(2, 'big')
         if mask:

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -57,10 +57,14 @@ class MatchDLVLAN(MatchField):
     @classmethod
     def from_of_tlv(cls, tlv):
         """Return an instance from a pyof OXM TLV."""
-        vlan_id = int.from_bytes(tlv.oxm_value[:2], 'big') & 4095
+        vlan_id = int.from_bytes(tlv.oxm_value[:2], 'big')
+        if vlan_id != 4096:
+            vlan_id &=  4095
         value = vlan_id
         if tlv.oxm_hasmask:
-            vlan_mask = int.from_bytes(tlv.oxm_value[2:], 'big') & 4095
+            vlan_mask = int.from_bytes(tlv.oxm_value[2:], 'big')
+            if vlan_mask != 4096:
+                vlan_mask &= 4095
             value = f'{vlan_id}/{vlan_mask}'
         return cls(value)
 

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -56,14 +56,19 @@ class MatchDLVLAN(MatchField):
 
     @classmethod
     def from_of_tlv(cls, tlv):
-        """Return an instance from a pyof OXM TLV."""
+        """Return an instance from a pyof OXM TLV.
+        *oxm_value=0x1000/0x1000 is a valid case. It's necessary to
+        deserialize 0x1000 as 4096 thus it is ignore to not obtain 0
+        """
         vlan_id = int.from_bytes(tlv.oxm_value[:2], 'big')
         if vlan_id != 4096:
+            # Ignore 4096
             vlan_id &= 4095
         value = vlan_id
         if tlv.oxm_hasmask:
             vlan_mask = int.from_bytes(tlv.oxm_value[2:], 'big')
             if vlan_mask != 4096:
+                # Ignore 4096
                 vlan_mask &= 4095
             value = f'{vlan_id}/{vlan_mask}'
         return cls(value)

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -37,14 +37,14 @@ class MatchDLVLAN(MatchField):
         """Return a pyof OXM TLV instance."""
         try:
             value = int(self.value)
+            value = value | VlanId.OFPVID_PRESENT
+            if value == 0:
+                value = VlanId.OFPVID_NONE
             mask = None
             oxm_hasmask = False
         except ValueError:
             value, mask = map(int, self.value.split('/'))
             oxm_hasmask = True
-        if value == 0:
-            value = VlanId.OFPVID_NONE
-        else:
             value = value | VlanId.OFPVID_PRESENT
         value_bytes = value.to_bytes(2, 'big')
         if mask:

--- a/v0x04/match_fields.py
+++ b/v0x04/match_fields.py
@@ -59,7 +59,7 @@ class MatchDLVLAN(MatchField):
         """Return an instance from a pyof OXM TLV."""
         vlan_id = int.from_bytes(tlv.oxm_value[:2], 'big')
         if vlan_id != 4096:
-            vlan_id &=  4095
+            vlan_id &= 4095
         value = vlan_id
         if tlv.oxm_hasmask:
             vlan_mask = int.from_bytes(tlv.oxm_value[2:], 'big')


### PR DESCRIPTION
Related to mef_eline PR [#258](https://github.com/kytos-ng/mef_eline/pull/258)

### Summary
From `MatchDLVLAN.as_of_tlv()`, `self.value` now can be non-existent `VlanId.OFPVID_NONE`
From `MatchDLVLAN.from_of_tlv()`, `tlv.oxm_value` now can handle the `any` case with `oxm_value = '4096/4096'`

### Local Tests
Installing this EVC through `mef_eline` api:
```
{
    "name": "my evc1",
    "dynamic_backup_path": true,
    "enabled": true,
    "uni_a": {
        "tag": {"tag_type": 1, "value": "any"},
        "interface_id": "00:00:00:00:00:00:00:01:1"
        },
    "uni_z": {
        "tag": {"tag_type": 1, "value": "untagged"},
        "interface_id": "00:00:00:00:00:00:00:02:1"
        }
}
```
Does not trigger consistency check loop (alien, delete, missing, install) with different values for the UNI tags. Confirming that the de-serialization is working as desired.