### PR TITLE
fix: release 2022.3.1: experimenter class deser shouldn't use old `pyof ActionExperimenter.body`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2023-02-23
+***********************
+
+Fixed
+=====
+
+- ``from_of_instruction`` experimenter class deserialization shouldn't use ``pyof ActionExperimenter.body``
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -69,4 +69,3 @@ def test_add_experimenter_classes():
     experimenter, func = 0xff000002, lambda body: resp
     Action04.add_experimenter_classes(experimenter, func)
     assert Action04._experimenter_classes[experimenter] == func
-    assert Action04.get_experimenter_class(experimenter, b'\xff') == resp

--- a/v0x04/flow.py
+++ b/v0x04/flow.py
@@ -212,11 +212,6 @@ class Action(ActionFactoryBase):
         """Add a callable that take bytes to map to Experimenter Actions."""
         cls._experimenter_classes[int(experimenter)] = func
 
-    @classmethod
-    def get_experimenter_class(cls, experimenter: int, body: bytes):
-        """Get Experimenter class."""
-        return cls._experimenter_classes[int(experimenter)](body)
-
 
 class InstructionAction(InstructionBase):
     """Base class for instruction dealing with actions."""
@@ -238,13 +233,8 @@ class InstructionAction(InstructionBase):
     @classmethod
     def from_of_instruction(cls, of_instruction):
         """Create high-level Instruction from pyof Instruction."""
-        actions = []
-        for of_action in of_instruction.actions:
-            klass = Action
-            if isinstance(of_action, ActionExperimenter):
-                klass = Action.get_experimenter_class(of_action.experimenter,
-                                                      of_action.body.pack())
-            actions.append(klass.from_of_action(of_action))
+        actions = [Action.from_of_action(of_action)
+                   for of_action in of_instruction.actions]
         return cls(actions)
 
     def as_of_instruction(self):


### PR DESCRIPTION
Closes #103 

### Summary

See updated changelog file. 

This bug was a result of me using a older version of `pyof` when I fixed issue #87 on PR https://github.com/kytos-ng/of_core/pull/88, it fixed the original issue, but then I also relied on an old removed `body` value from `ActionExperimenter.body` which introduced this issue here. Since the classes are being registered correctly by `noviflow` NApp then `from_of_action` should work as it used to.

### Local Tests

- Installed both `push_int` and `pop_int` experimenter actions on a NoviFlow switch

```
kytos $> 2023-02-22 18:57:49,762 - INFO [kytos.napps.kytos/flow_manager] (Thread-92) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [{'priority': 100, 'match': {'in_port': 1}, 'actions': [{'action_type': 'push_int'}]}]}
2023-02-22 18:57:52,383 - INFO [kytos.napps.kytos/flow_manager] (Thread-93) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [{
'priority': 100, 'match': {'in_port': 2}, 'actions': [{'action_type': 'pop_int'}]}]}
kytos $>                                                                                                                                                                                 
```

### End-to-End Tests

I have dispatched an e2e execution, I don't expect much surprises though.

@jab1982 thanks for catching this issue and helping out to validate this branch. 