### PR TITLE
fix: gracefully handled `kytos/core.openflow.connection.error` when a switch hasn't been created yet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 =====
 
 - ``from_of_instruction`` experimenter class deserialization shouldn't use ``pyof ActionExperimenter.body``
+- Gracefully handled ``kytos/core.openflow.connection.error`` when a switch hasn't been created yet
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/main.py
+++ b/main.py
@@ -510,7 +510,10 @@ class Main(KytosNApp):
     @alisten_to("kytos/core.openflow.connection.error")
     async def on_openflow_connection_error(self, event):
         """On openflow connection error try to pop multipart replies."""
-        self.pop_multipart_replies(event.content["destination"].switch)
+        switch = event.content["destination"].switch
+        if not switch:
+            return
+        self.pop_multipart_replies(switch)
 
     def shutdown(self):
         """End of the application."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -350,6 +350,14 @@ class TestNApp:
         assert dpid not in napp._multipart_replies_flows
         assert dpid not in napp._multipart_replies_ports
 
+    async def test_on_openflow_connection_error_no_sw(self, napp) -> None:
+        """Test on_openflow_connection_error no switch."""
+        event = MagicMock()
+        napp.pop_multipart_replies = MagicMock()
+        event.content["destination"].switch = None
+        await napp.on_openflow_connection_error(event)
+        assert napp.pop_multipart_replies.call_count == 0
+
 
 class TestMain(TestCase):
     """Test the Main class."""


### PR DESCRIPTION
Closes #110 

### Summary

See updated changelog file

### Local Tests

Rerun `kytosd` again with this branch:

```
kytos $> 2023-04-11 18:00:42,727 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:48032                                                                         
2023-04-11 18:00:42,728 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:48038
2023-04-11 18:00:42,732 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:48050
2023-04-11 18:00:43,263 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_0) Connection ('127.0.0.1', 48032), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2023-04-11 18:00:43,275 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_1) Connection ('127.0.0.1', 48038), Switch 00:00:00:00:00:00:00:03: OPENFLOW HANDSHAKE COMPLETE
2023-04-11 18:00:43,285 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_2) Connection ('127.0.0.1', 48050), Switch 00:00:00:00:00:00:00:02: OPENFLOW HANDSHAKE COMPLETE

```

### End-to-End Tests

e2e isn't necessary since it's not changing implementation behavior, and unit test covered it. 