### PR TITLE
feature: Receive table stats

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changed
 =======
 - ``MatchDLVLAN`` can handle values such as ``"4096/4096"`` and 0
 
+Added
+=====
+- New event ``kytos/of_core.table_stats.received`` to notify when new table statistics are available.
+
 
 [2022.3.1] - 2023-02-23
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,22 @@ Content:
     'replies_flows': <list of Flow04>
    }
 
+kytos/of_core.table_stats.received
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting that OpenFlow multipart OFPMP_TABLE message has been received.
+
+This event includes the switch with tables.
+
+Content:
+
+.. code-block:: python
+
+   {
+    'switch': <switch>,
+    'replies_tables': <list of TableStats>
+   }
+
 kytos/of_core.reachable.mac
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import time
 from collections import defaultdict
 
 from napps.kytos.of_core import settings
+from napps.kytos.of_core.table import TableStats
 from napps.kytos.of_core.utils import (GenericHello, NegotiationException,
                                        aemit_message_in, aemit_message_out,
                                        emit_message_in, emit_message_out,
@@ -35,6 +36,7 @@ class Main(KytosNApp):
     _multipart_replies_xids = {}
     _multipart_replies_flows = defaultdict(list)
     _multipart_replies_ports = defaultdict(list)
+    _multipart_replies_tables = defaultdict(list)
 
     def setup(self):
         """App initialization (used instead of ``__init__``).
@@ -73,7 +75,8 @@ class Main(KytosNApp):
     def _check_overlapping_multipart_request(self, switch):
         """Check overlapping multipart stats request (OF 1.3 only)."""
         current_req = self._multipart_replies_xids.get(switch.id, {})
-        if ('flows' in current_req or 'ports' in current_req) and \
+        if ('flows' in current_req or 'ports' in current_req or
+           'tables' in current_req) and \
            current_req.get('skipped', 0) < settings.STATS_REQ_SKIP:
             log.info("Overlapping stats request: switch %s flows_xid %s"
                      " ports_xid %s", switch.id, current_req.get('flows'),
@@ -85,6 +88,8 @@ class Main(KytosNApp):
             del self._multipart_replies_flows[switch.id]
         if switch.id in self._multipart_replies_ports:
             del self._multipart_replies_ports[switch.id]
+        if switch.id in self._multipart_replies_tables:
+            del self._multipart_replies_tables[switch.id]
         return False
 
     def _get_switch_req_stats_delay(self, switch):
@@ -109,8 +114,13 @@ class Main(KytosNApp):
                                                              switch)
             xid_ports = of_core_v0x04_utils.request_port_stats(self.controller,
                                                                switch)
-            self._multipart_replies_xids[switch.id] = {'flows': xid_flows,
-                                                       'ports': xid_ports}
+            xid_tables = of_core_v0x04_utils.update_table_list(self.controller,
+                                                               switch)
+            self._multipart_replies_xids[switch.id] = {
+                                                        'flows': xid_flows,
+                                                        'ports': xid_ports,
+                                                        'tables': xid_tables
+                                                      }
 
     @listen_to('kytos/of_core.v0x04.messages.in.ofpt_features_reply')
     def on_features_reply(self, event):
@@ -163,6 +173,8 @@ class Main(KytosNApp):
         """Handle multipart replies for v0x04 switches."""
         if reply.multipart_type == MultipartType.OFPMP_FLOW:
             await self._handle_multipart_flow_stats(reply, switch)
+        elif reply.multipart_type == MultipartType.OFPMP_TABLE:
+            await self._handle_multipart_table_stats(reply, switch)
         elif reply.multipart_type == MultipartType.OFPMP_PORT_STATS:
             await self._handle_multipart_port_stats(reply, switch)
         elif reply.multipart_type == MultipartType.OFPMP_PORT_DESC:
@@ -199,6 +211,38 @@ class Main(KytosNApp):
                 await self.controller.buffers.app.aput(event_raw)
                 return True
 
+    async def _handle_multipart_table_stats(self, reply, switch):
+        """Update switch tables after all replies are received.
+
+        Returns true if no more replies are expected.
+        """
+        if self._is_multipart_reply_ours(reply, switch, 'tables'):
+            # Get all tables from the reply and extend the multipar tables list
+            tables = [TableStats.from_of_table_stats(of_table_stats, switch)
+                      for of_table_stats in reply.body]
+            self._multipart_replies_tables[switch.id].extend(tables)
+            xid = int(reply.header.xid)
+            if reply.flags.value % 2 == 0:  # Last bit means more replies
+                try:
+                    replies_tables = [
+                        table for table
+                        in self._multipart_replies_tables[switch.id]
+                    ]
+                    self._update_switch_tables(switch)
+                except KeyError:
+                    log.error("Skipped tables stats reply due to error when"
+                              f"updating switch {switch.id}, xid {xid}")
+                    return
+                event_raw = KytosEvent(
+                    name='kytos/of_core.table_stats.received',
+                    content={
+                                'switch': switch,
+                                'replies_tables': replies_tables
+                            })
+                await self.controller.buffers.app.aput(event_raw)
+                log.info(f"Table stats received: {len(replies_tables)} tables")
+                return True
+
     async def _handle_multipart_port_stats(self, reply, switch):
         """Emit an event about new port stats."""
         if self._is_multipart_reply_ours(reply, switch, 'ports'):
@@ -212,6 +256,12 @@ class Main(KytosNApp):
         switch.flows = self._multipart_replies_flows[switch.id]
         del self._multipart_replies_flows[switch.id]
         del self._multipart_replies_xids[switch.id]['flows']
+
+    def _update_switch_tables(self, switch):
+        """Update controllers' switch tables list and clean resources."""
+        switch.tables = self._multipart_replies_tables[switch.id]
+        del self._multipart_replies_tables[switch.id]
+        del self._multipart_replies_xids[switch.id]['tables']
 
     async def _new_port_stats(self, switch):
         """Send an event with the new port stats and clean resources."""
@@ -506,6 +556,7 @@ class Main(KytosNApp):
         self._multipart_replies_xids.pop(switch.id, None)
         self._multipart_replies_flows.pop(switch.id, None)
         self._multipart_replies_ports.pop(switch.id, None)
+        self._multipart_replies_tables.pop(switch.id, None)
 
     @alisten_to("kytos/core.openflow.connection.error")
     async def on_openflow_connection_error(self, event):

--- a/main.py
+++ b/main.py
@@ -240,7 +240,6 @@ class Main(KytosNApp):
                                 'replies_tables': replies_tables
                             })
                 await self.controller.buffers.app.aput(event_raw)
-                log.info(f"Table stats received: {len(replies_tables)} tables")
                 return True
 
     async def _handle_multipart_port_stats(self, reply, switch):

--- a/main.py
+++ b/main.py
@@ -61,7 +61,7 @@ class Main(KytosNApp):
         """
         for switch in self.controller.switches.copy().values():
             if switch.is_connected():
-                self.request_list(switch)
+                self.request_stats(switch)
                 if settings.SEND_ECHO_REQUESTS:
                     version_utils = \
                         self.of_core_version_utils[switch.
@@ -69,9 +69,9 @@ class Main(KytosNApp):
                     version_utils.send_echo(self.controller, switch)
 
     @run_on_thread
-    def request_list(self, switch):
+    def request_stats(self, switch):
         """Send flow stats request to a connected switch."""
-        self._request_list(switch)
+        self._request_stats(switch)
 
     def _check_overlapping_multipart_request(self, switch):
         """Check overlapping multipart stats request (OF 1.3 only)."""
@@ -103,7 +103,7 @@ class Main(KytosNApp):
         self.switch_req_stats_delay['last'] = next_delay
         return next_delay
 
-    def _request_list(self, switch):
+    def _request_stats(self, switch):
         """Send flow stats request to a connected switch."""
         time.sleep(self._get_switch_req_stats_delay(switch))
         of_version = switch.connection.protocol.version
@@ -160,7 +160,7 @@ class Main(KytosNApp):
             self.controller.buffers.app.put(event_raw)
 
     @listen_to('kytos/of_core.handshake.completed')
-    def on_handshake_completed_request_list(self, event):
+    def on_handshake_completed_request_stats(self, event):
         """Request a flow list right after the handshake is completed.
 
         Args:
@@ -168,11 +168,11 @@ class Main(KytosNApp):
         """
         switch = event.content['switch']
         if switch.is_enabled():
-            self.handle_handshake_completed_request_list(switch)
+            self.handle_handshake_completed_request_stats(switch)
 
-    def handle_handshake_completed_request_list(self, switch):
+    def handle_handshake_completed_request_stats(self, switch):
         """Request a flow list right after the handshake is completed."""
-        self._request_list(switch)
+        self._request_stats(switch)
 
     async def _handle_multipart_reply(self, reply, switch):
         """Handle multipart replies for v0x04 switches."""

--- a/main.py
+++ b/main.py
@@ -119,13 +119,16 @@ class Main(KytosNApp):
                                                         'flows': xid_flows,
                                                         'ports': xid_ports
                                                       }
-            if switch.features.capabilities.value & \
-                Capabilities.OFPC_TABLE_STATS == \
-                    Capabilities.OFPC_TABLE_STATS:
-                xid_tables = of_core_v0x04_utils.request_table_stats(
-                    self.controller, switch)
-                self._multipart_replies_xids[switch.id].update(
-                    {'tables': xid_tables})
+            try:
+                if switch.features.capabilities.value & \
+                    Capabilities.OFPC_TABLE_STATS == \
+                        Capabilities.OFPC_TABLE_STATS:
+                    xid_tables = of_core_v0x04_utils.request_table_stats(
+                        self.controller, switch)
+                    self._multipart_replies_xids[switch.id].update(
+                        {'tables': xid_tables})
+            except AttributeError as err:
+                log.error(f"Capabilities not set on switch {switch.id}: {err}")
 
     @listen_to('kytos/of_core.v0x04.messages.in.ofpt_features_reply')
     def on_features_reply(self, event):

--- a/table.py
+++ b/table.py
@@ -1,11 +1,10 @@
 """High-level abstraction for Tables of multiple OpenFlow versions.
 """
 import json
-from abc import ABC
 
 
-class TableStats(ABC):
-    """Class to abstract a Table to switches.
+class TableStats:
+    """Class with table fields.
     """
 
     def __init__(self, switch, table_id=0x0, active_count=0,

--- a/table.py
+++ b/table.py
@@ -1,0 +1,79 @@
+"""High-level abstraction for Tables of multiple OpenFlow versions.
+"""
+import json
+from abc import ABC
+
+
+class TableStats(ABC):
+    """Class to abstract a Table to switches.
+    """
+
+    def __init__(self, switch, table_id=0x0, active_count=0,
+                 lookup_count=0, matched_count=0):
+        """Assign parameters to attributes.
+
+        Args:
+            switch (kytos.core.switch.Switch): Switch ID is used to uniquely
+                identify a flow.
+            table_id (int): The index of a single table or 0xff for all tables.
+            active_count: Number of active entries.
+            lookup_count: Number of packets looked up in table.
+            matched_count: Number of packets that hit table.
+        """
+        self.switch = switch
+        self.table_id = table_id
+        self.active_count = active_count
+        self.lookup_count = lookup_count
+        self.matched_count = matched_count
+
+    def as_dict(self):
+        """Return the Table as a serializable Python dictionary.
+        """
+        table_dict = {
+            'switch': self.switch.id,
+            'table_id': self.table_id,
+            'active_count': self.active_count,
+            'lookup_count': self.lookup_count,
+            'matched_count': self.matched_count
+        }
+
+        return table_dict
+
+    @classmethod
+    def from_dict(cls, table_dict, switch):
+        """Return an instance with values from ``table_dict``."""
+        table = cls(switch)
+
+        for attr_name, attr_value in table_dict.items():
+            if attr_name in vars(table):
+                setattr(table, attr_name, attr_value)
+
+        table.switch = switch
+        return table
+
+    def as_json(self, sort_keys=False):
+        """Return the representation of a flow in JSON format.
+
+        Args:
+            sort_keys (bool): ``False`` by default (Python's default).
+        Returns:
+            string: Flow JSON string representation.
+
+        """
+        return json.dumps(self.as_dict(), sort_keys=sort_keys)
+
+    @classmethod
+    def from_of_table_stats(cls, of_table_stats, switch):
+        """Create a flow with latest stats based on pyof FlowStats."""
+        return cls(switch,
+                   table_id=of_table_stats.table_id.value,
+                   active_count=of_table_stats.active_count.value,
+                   lookup_count=of_table_stats.lookup_count.value,
+                   matched_count=of_table_stats.matched_count.value)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            raise ValueError(f'Error comparing tables: {other} is not '
+                             f'an instance of {self.__class__}')
+
+        return self.as_dict() == other.as_dict()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -58,7 +58,7 @@ class TestAsync:
         """Auxiliar function to get switch mock"""
         switch.features = MagicMock()
         switch.features.capabilities = MagicMock()
-        switch.features.capabilities.value = 1
+        switch.features.capabilities.value = 2
         return switch
 
     async def test_handle_hello_raw_in(self):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,7 +1,7 @@
 """Integration test main."""
 # pylint: disable=wrong-import-order,protected-access
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from pyof.v0x04.controller2switch.features_reply import \
     FeaturesReply as FReply_v0x04
@@ -40,8 +40,9 @@ class TestAsync:
         sw_ = self.napp.controller.get_switch_or_create(dpid_02,
                                                         sw_04.connection)
         sw_.is_connected = lambda: True
+        sw_ = self._add_features_switch(sw_)
         # pylint: disable=protected-access
-        self.napp.request_flow_list = self.napp._request_flow_list
+        self.napp.request_list = self.napp._request_list
         self.napp.execute()
         mock_sleep.assert_called()
         expected = [
@@ -52,6 +53,13 @@ class TestAsync:
         for message in expected:
             of_event = self.napp.controller.buffers.msg_out.get()
             assert of_event.name == message
+
+    def _add_features_switch(self, switch):
+        """Auxiliar function to get switch mock"""
+        switch.features = MagicMock()
+        switch.features.capabilities = MagicMock()
+        switch.features.capabilities.value = 73
+        return switch
 
     async def test_handle_hello_raw_in(self):
         """Test handling hello raw in message."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -42,7 +42,7 @@ class TestAsync:
         sw_.is_connected = lambda: True
         sw_ = self._add_features_switch(sw_)
         # pylint: disable=protected-access
-        self.napp.request_list = self.napp._request_list
+        self.napp.request_stats = self.napp._request_stats
         self.napp.execute()
         mock_sleep.assert_called()
         expected = [
@@ -58,7 +58,7 @@ class TestAsync:
         """Auxiliar function to get switch mock"""
         switch.features = MagicMock()
         switch.features.capabilities = MagicMock()
-        switch.features.capabilities.value = 73
+        switch.features.capabilities.value = 1
         return switch
 
     async def test_handle_hello_raw_in(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -433,20 +433,20 @@ class TestMain(TestCase):
     @patch('napps.kytos.of_core.v0x04.utils.send_echo')
     def test_execute(self, mock_of_core_v0x04_utils):
         """Test execute."""
-        self.napp.request_list = MagicMock()
+        self.napp.request_stats = MagicMock()
         self.switch_v0x04.is_connected.return_value = True
 
         self.napp.controller.switches = {"00:00:00:00:00:00:00:01":
                                          self.switch_v0x04}
         self.napp.execute()
         mock_of_core_v0x04_utils.assert_called()
-        assert self.napp.request_list.call_count == 1
+        assert self.napp.request_stats.call_count == 1
 
     def _add_features_switch(self, switch):
         """Auxiliar function to get switch mock"""
         switch.features = MagicMock()
         switch.features.capabilities = MagicMock()
-        switch.features.capabilities.value = 73
+        switch.features.capabilities.value = 1
         return switch
 
     @patch('napps.kytos.of_core.main.settings')
@@ -507,29 +507,29 @@ class TestMain(TestCase):
     @patch('napps.kytos.of_core.main.Main.'
            '_check_overlapping_multipart_request')
     @patch('napps.kytos.of_core.v0x04.utils.update_flow_list')
-    def test_request_list(self, *args):
+    def test_request_stats(self, *args):
         """Test request flow list."""
         (mock_update_flow_list_v0x04, mock_check_overlapping_multipart_request,
             _) = args
         mock_update_flow_list_v0x04.return_value = 0xABC
         mock_check_overlapping_multipart_request.return_value = False
-        self.napp._request_list(self.switch_v0x04)
+        self.napp._request_stats(self.switch_v0x04)
         mock_update_flow_list_v0x04.assert_called_with(self.napp.controller,
                                                        self.switch_v0x04)
 
         mock_update_flow_list_v0x04.call_count = 0
         mock_check_overlapping_multipart_request.return_value = True
-        self.napp._request_list(self.switch_v0x04)
+        self.napp._request_stats(self.switch_v0x04)
         mock_update_flow_list_v0x04.assert_not_called()
 
     @patch('time.sleep', return_value=None)
     @patch('napps.kytos.of_core.v0x04.utils.update_flow_list')
-    def test_on_handshake_completed_request_list(self, *args):
+    def test_on_handshake_completed_request_stats(self, *args):
         """Test request flow list."""
         (mock_update_flow_list_v0x04, _) = args
         mock_update_flow_list_v0x04.return_value = 0xABC
         sw = self.switch_v0x04
-        self.napp.handle_handshake_completed_request_list(sw)
+        self.napp.handle_handshake_completed_request_stats(sw)
         mock_update_flow_list_v0x04.assert_called_with(self.napp.controller,
                                                        self.switch_v0x04)
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1,0 +1,69 @@
+"""Tests for high-level Flow of OpenFlow 1.3."""
+from unittest import TestCase
+
+from kytos.lib.helpers import get_switch_mock
+from napps.kytos.of_core.table import TableStats
+
+
+class TestTableStats(TestCase):
+    """Test TableStats Class."""
+
+    def test__eq__success_with_equal(self):
+        """Test success case to __eq__ override with equal tables."""
+        mock_switch = get_switch_mock("00:00:00:00:00:00:00:01")
+
+        table_dict = {
+                        'switch': mock_switch.id,
+                        'table_id': 1,
+                        'active_count': 0,
+                        'lookup_count': 0,
+                        'matched_count': 0
+                     }
+
+        with self.subTest(table_class=TableStats):
+            table_1 = TableStats.from_dict(table_dict, mock_switch)
+            table_2 = TableStats.from_dict(table_dict, mock_switch)
+            self.assertEqual(table_1 == table_2, True)
+
+    def test__eq__success_with_different_tables(self):
+        """Test success case to __eq__ override with different tables."""
+        mock_switch = get_switch_mock("00:00:00:00:00:00:00:01")
+
+        table_dict_1 = {
+                            'switch': mock_switch.id,
+                            'table_id': 1,
+                            'active_count': 0,
+                            'lookup_count': 0,
+                            'matched_count': 0
+                       }
+
+        table_dict_2 = {
+                            'switch': mock_switch.id,
+                            'table_id': 2,
+                            'active_count': 1,
+                            'lookup_count': 2,
+                            'matched_count': 3
+                       }
+
+        with self.subTest(table_class=TableStats):
+            table_1 = TableStats.from_dict(table_dict_1, mock_switch)
+            table_2 = TableStats.from_dict(table_dict_2, mock_switch)
+            self.assertEqual(table_1 == table_2, False)
+
+    def test__eq__fail(self):
+        """Test the case where __eq__ receives objects with different types."""
+        mock_switch = get_switch_mock("00:00:00:00:00:00:00:01")
+
+        table_dict = {
+                        'switch': mock_switch.id,
+                        'table_id': 1,
+                        'active_count': 0,
+                        'lookup_count': 0,
+                        'matched_count': 0
+                     }
+
+        with self.subTest(table_class=TableStats):
+            table_1 = TableStats.from_dict(table_dict, mock_switch)
+            table_2 = "string_object"
+            with self.assertRaises(ValueError):
+                return table_1 == table_2

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1,69 +1,83 @@
-"""Tests for high-level Flow of OpenFlow 1.3."""
-from unittest import TestCase
+"""Tests for Tables"""
+import pytest
 
 from kytos.lib.helpers import get_switch_mock
 from napps.kytos.of_core.table import TableStats
 
 
-class TestTableStats(TestCase):
+class TestTableStats():
     """Test TableStats Class."""
 
-    def test__eq__success_with_equal(self):
+    @pytest.mark.parametrize(
+        "table_dict",
+        [
+            (
+                {
+                    'switch': "00:00:00:00:00:00:00:01",
+                    'table_id': 1,
+                    'active_count': 0,
+                    'lookup_count': 0,
+                    'matched_count': 0,
+                }
+            ),
+        ],
+    )
+    def test__eq__success_with_equal(self, table_dict):
         """Test success case to __eq__ override with equal tables."""
         mock_switch = get_switch_mock("00:00:00:00:00:00:00:01")
 
-        table_dict = {
-                        'switch': mock_switch.id,
-                        'table_id': 1,
-                        'active_count': 0,
-                        'lookup_count': 0,
-                        'matched_count': 0
-                     }
+        table_1 = TableStats.from_dict(table_dict, mock_switch)
+        table_2 = TableStats.from_dict(table_dict, mock_switch)
+        assert table_1 == table_2
 
-        with self.subTest(table_class=TableStats):
-            table_1 = TableStats.from_dict(table_dict, mock_switch)
-            table_2 = TableStats.from_dict(table_dict, mock_switch)
-            self.assertEqual(table_1 == table_2, True)
-
-    def test__eq__success_with_different_tables(self):
+    @pytest.mark.parametrize(
+        "table_dict1, table_dict2",
+        [
+            (
+                {
+                    'switch': "00:00:00:00:00:00:00:01",
+                    'table_id': 1,
+                    'active_count': 0,
+                    'lookup_count': 0,
+                    'matched_count': 0
+                },
+                {
+                    'switch': "00:00:00:00:00:00:00:01",
+                    'table_id': 2,
+                    'active_count': 1,
+                    'lookup_count': 2,
+                    'matched_count': 3
+                }
+            ),
+        ],
+    )
+    def test__eq__success_different_tables(self, table_dict1, table_dict2):
         """Test success case to __eq__ override with different tables."""
         mock_switch = get_switch_mock("00:00:00:00:00:00:00:01")
 
-        table_dict_1 = {
-                            'switch': mock_switch.id,
-                            'table_id': 1,
-                            'active_count': 0,
-                            'lookup_count': 0,
-                            'matched_count': 0
-                       }
+        table_1 = TableStats.from_dict(table_dict1, mock_switch)
+        table_2 = TableStats.from_dict(table_dict2, mock_switch)
+        assert table_1 != table_2
 
-        table_dict_2 = {
-                            'switch': mock_switch.id,
-                            'table_id': 2,
-                            'active_count': 1,
-                            'lookup_count': 2,
-                            'matched_count': 3
-                       }
-
-        with self.subTest(table_class=TableStats):
-            table_1 = TableStats.from_dict(table_dict_1, mock_switch)
-            table_2 = TableStats.from_dict(table_dict_2, mock_switch)
-            self.assertEqual(table_1 == table_2, False)
-
-    def test__eq__fail(self):
+    @pytest.mark.parametrize(
+        "table_dict",
+        [
+            (
+                {
+                    'switch': "00:00:00:00:00:00:00:01",
+                    'table_id': 1,
+                    'active_count': 0,
+                    'lookup_count': 0,
+                    'matched_count': 0,
+                }
+            ),
+        ],
+    )
+    def test__eq__fail(self, table_dict):
         """Test the case where __eq__ receives objects with different types."""
         mock_switch = get_switch_mock("00:00:00:00:00:00:00:01")
 
-        table_dict = {
-                        'switch': mock_switch.id,
-                        'table_id': 1,
-                        'active_count': 0,
-                        'lookup_count': 0,
-                        'matched_count': 0
-                     }
-
-        with self.subTest(table_class=TableStats):
-            table_1 = TableStats.from_dict(table_dict, mock_switch)
-            table_2 = "string_object"
-            with self.assertRaises(ValueError):
-                return table_1 == table_2
+        table_1 = TableStats.from_dict(table_dict, mock_switch)
+        table_2 = "string_object"
+        with pytest.raises(ValueError):
+            return table_1 == table_2

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -65,6 +65,25 @@ def request_port_stats(controller, switch):
     return multipart_request.header.xid
 
 
+def update_table_list(controller, switch):
+    """Request table stats from switches.
+
+    Args:
+        controller(:class:`~kytos.core.controller.Controller`):
+            the controller being used.
+        switch(:class:`~kytos.core.switch.Switch`):
+            target to send a stats request.
+
+    Returns:
+        int: multipart request xid
+
+    """
+    multipart_request = MultipartRequest()
+    multipart_request.multipart_type = MultipartType.OFPMP_TABLE
+    emit_message_out(controller, switch.connection, multipart_request)
+    return multipart_request.header.xid
+
+
 def send_desc_request(controller, switch):
     """Request vendor-specific switch description.
 

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -65,7 +65,7 @@ def request_port_stats(controller, switch):
     return multipart_request.header.xid
 
 
-def update_table_list(controller, switch):
+def request_table_stats(controller, switch):
     """Request table stats from switches.
 
     Args:


### PR DESCRIPTION
Closes #113 

### Summary

Add `update_table_list` to start receiving `MultipartType.OFPMP_TABLE`.
Add a new class: TableStats for the data received from `MultipartType.OFPMP_TABLE`
Add `_handle_multipart_table_stats` to get the data and publish a new event: `kytos/of_core.table_stats.received`

### Local Tests

I made sure to get messages with table stats by putting a temporary log:

```
2023-05-13 00:11:45,166 - INFO [kytos.napps.kytos/of_core] (MainThread) Table stats received: 254 tables
```

### End-to-End Tests

Progress..