### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.1.0] - 2023-06-05
+***********************
+
 Changed
 =======
 - ``MatchDLVLAN`` can handle values such as ``"4096/4096"`` and 0

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2022.3.1",
+  "version": "2023.1.0",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",


### PR DESCRIPTION
### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Not needed (e2e nightly tests are passing)
