### PR TITLE
fix: multipart replies clean up now happens before connection gets established to be safer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Multipart replies clean up now happens before connection gets established to be safer
+
+
 [2023.1.0] - 2023-06-05
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -147,6 +147,7 @@ class Main(KytosNApp):
         version_utils = self.of_core_version_utils[connection.protocol.version]
         switch = version_utils.handle_features_reply(self.controller, event)
         switch.update_lastseen()
+        self.pop_multipart_replies(switch)
 
         if (connection.is_during_setup() and
                 connection.protocol.state == 'waiting_features_reply'):
@@ -544,14 +545,6 @@ class Main(KytosNApp):
         """Close the connection upon hello failure."""
         event.destination.close()
         log.debug("Connection %s: Connection closed.", event.destination.id)
-
-    @alisten_to(".*.connection.lost")
-    async def on_connection_lost(self, event) -> None:
-        """On connection_lost event."""
-        switch = event.content["source"].switch
-        if not switch:
-            return
-        self.pop_multipart_replies(switch)
 
     def pop_multipart_replies(self, switch) -> None:
         """Pop multipart replies."""


### PR DESCRIPTION
Closes #123 (thanks @italovalcy for catching this and your initial analysis)

### Summary

See updated changelog file

### Local Tests

I simulated a few reconnections, it's working as expected:

```
kytos $> 2023-09-19 16:14:29,234 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:51212. Reason: Request closed by client                              
2023-09-19 16:14:30,736 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:51352
kytos $>                                                                                                                                                                                 

kytos $> 2023-09-19 16:14:33,127 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_11) Connection ('127.0.0.1', 51352), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE     
2023-09-19 16:14:33,137 - INFO [kytos.napps.kytos/of_lldp] (thread_pool_app_3) handle_lldp_flows for kytos/topology.switch.enabled
2023-09-19 16:14:33,167 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]: 
[{'actions': [{'action_type': 'output', 'port': 4294967293}], 'table_id': 0, 'owner': 'of_lldp', 'table_group': 'base', 'priority': 50000, 'cookie': 12321848580485677057, 'match': {'dl_
type': 35020, 'dl_vlan': 3799}}]
2023-09-19 16:14:33,176 - INFO [uvicorn.access] (MainThread) 127.0.0.1:55454 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
kytos $>                                                                                                                                                                                 

kytos $> 2023-09-19 16:14:37,281 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:51352. Reason: Request closed by client                              
2023-09-19 16:14:38,164 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:51368
2023-09-19 16:14:38,292 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_5) Connection ('127.0.0.1', 51368), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2023-09-19 16:14:38,317 - INFO [kytos.napps.kytos/of_lldp] (thread_pool_app_8) handle_lldp_flows for kytos/topology.switch.enabled
2023-09-19 16:14:38,341 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]: 
[{'actions': [{'action_type': 'output', 'port': 4294967293}], 'table_id': 0, 'owner': 'of_lldp', 'table_group': 'base', 'priority': 50000, 'cookie': 12321848580485677057, 'match': {'dl_
type': 35020, 'dl_vlan': 3799}}]
2023-09-19 16:14:38,349 - INFO [uvicorn.access] (MainThread) 127.0.0.1:55470 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202

```

### End-to-End Tests

I'll dispatch e2e exec with this branch on GitLab:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 241 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 47%]
...                                                                      [ 48%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 72%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 75%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 85%]
tests/test_e2e_50_maintenance.py ........................                [ 95%]
tests/test_e2e_60_of_multi_table.py .....                                [ 97%]
tests/test_e2e_70_kytos_stats.py .......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 219 passed, 6 skipped, 11 xfailed, 5 xpassed, 867 warnings in 11433.75s (3:10:33) =
```

