### PR TITLE
release: bumped 2023.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.0] - 2024-02-16
+***********************
+
 Fixed
 =====
 - Multipart replies clean up now happens before connection gets established to be safer

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2023.1.0",
+  "version": "2023.2.0",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",


### PR DESCRIPTION
### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A nightly e2e tests are passing
