### PR TITLE
fix: set interface.speed on PortStatus reason OFPPR_ADD and OFPPR_MODIFY

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the of_core NApp will be documented in this file.
 Fixed
 =====
 - Multipart replies clean up now happens before connection gets established to be safer
+- Set ``interface.speed`` on ``PortStatus`` reason ``OFPPR_ADD`` and ``OFPPR_MODIFY``
 
 
 [2023.1.0] - 2023-06-05

--- a/main.py
+++ b/main.py
@@ -672,7 +672,7 @@ class Main(KytosNApp):
                 interface.name = port.name.value
                 interface.address = port.hw_addr.value
                 interface.features = port.curr
-                interface.speed = port.curr_speed.value
+                interface.set_custom_speed(port.curr_speed.value)
             else:
                 interface = Interface(name=port.name.value,
                                       address=port.hw_addr.value,

--- a/main.py
+++ b/main.py
@@ -657,6 +657,7 @@ class Main(KytosNApp):
                                   port_number=port_no,
                                   switch=source.switch,
                                   state=port.state.value,
+                                  speed=port.curr_speed.value,
                                   features=port.curr)
             source.switch.update_interface(interface)
             try_to_activate_interface(interface, port)
@@ -671,12 +672,14 @@ class Main(KytosNApp):
                 interface.name = port.name.value
                 interface.address = port.hw_addr.value
                 interface.features = port.curr
+                interface.speed = port.curr_speed.value
             else:
                 interface = Interface(name=port.name.value,
                                       address=port.hw_addr.value,
                                       port_number=port_no,
                                       switch=source.switch,
                                       state=port.state.value,
+                                      speed=port.curr_speed.value,
                                       features=port.curr)
             source.switch.update_interface(interface)
             try_to_activate_interface(interface, port)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -747,6 +747,8 @@ class TestMain:
         mock_source = MagicMock()
         mock_port = MagicMock()
         mock_port.state.value = PortState.OFPPS_LIVE
+        speed = 10000000
+        mock_port.curr_speed.value = speed
 
         mock_port_status.reason.value.side_effect = [0, 1, 2]
         mock_port_status.reason.enum_ref(0).name = 'OFPPR_ADD'
@@ -754,6 +756,7 @@ class TestMain:
         self.napp.update_port_status(mock_port_status, mock_source)
         mock_interface.assert_called()
         assert mock_intf.activate.call_count == 1
+        assert mock_interface.call_args[1]["speed"] == speed
 
         # check OFPRR_MODIFY
         mock_port_status.reason.enum_ref(1).name = 'OFPPR_MODIFY'
@@ -762,9 +765,12 @@ class TestMain:
         mock_port_mod.assert_called()
         mock_buffer_put.assert_called()
         assert mock_intf.activate.call_count == 2
+        assert mock_interface.call_args[1]["speed"] == speed
 
-        mock_source.switch.get_interface_by_port_no.return_value = MagicMock()
+        mock_source.switch.get_interface_by_port_no.return_value = mock_intf
+        assert mock_intf.speed != speed
         self.napp.update_port_status(mock_port_status, mock_source)
+        assert mock_intf.speed == speed
         mock_port_mod.assert_called()
         mock_buffer_put.assert_called()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -768,9 +768,8 @@ class TestMain:
         assert mock_interface.call_args[1]["speed"] == speed
 
         mock_source.switch.get_interface_by_port_no.return_value = mock_intf
-        assert mock_intf.speed != speed
         self.napp.update_port_status(mock_port_status, mock_source)
-        assert mock_intf.speed == speed
+        mock_intf.set_custom_speed.assert_called_with(speed)
         mock_port_mod.assert_called()
         mock_buffer_put.assert_called()
 


### PR DESCRIPTION
Closes #132 

### Summary

See updated changelog file 

### Local Tests

- Simulated a few PortStatus and it behaved as expected

```
kytos $> 2024-03-05 13:08:28,954 - INFO [uvicorn.access] (MainThread) 127.0.0.1:55682 - "GET /api/kytos/topology/v3/ HTTP/1.1" 200                                                       
2024-03-05 13:08:28,959 - INFO [uvicorn.access] (MainThread) 127.0.0.1:55684 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&cookie_range=12321848580485677056&cookie_rang
e=12393906174523604991&dpid=00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 200
2024-03-05 13:08:31,187 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_0) Event handle_link_up Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s2-eth2
', 2, Switch('00:00:00:00:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-03-05 13:08:31,190 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_2) Event handle_link_up Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth2
', 2, Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
2024-03-05 13:08:36,583 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_0) Event handle_link_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth3
', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-03-05 13:08:39,673 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state 0
2024-03-05 13:08:39,673 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LINK_DOWN
2024-03-05 13:08:39,674 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state 0
2024-03-05 13:08:39,674 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LINK_DOWN
2024-03-05 13:08:39,677 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth
3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-03-05 13:08:39,776 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_16) Event handle_interface_link_down Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-03-05 13:08:39,777 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_7) Event handle_interface_link_down Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
2024-03-05 13:08:43,651 - INFO [uvicorn.access] (MainThread) 127.0.0.1:50594 - "GET /api/kytos/topology/v3/ HTTP/1.1" 200
2024-03-05 13:08:57,218 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2024-03-05 13:08:57,219 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
kytos $>                                                                                                                                                                                 

kytos $> controller.get_interface_by_id('00:00:00:00:00:00:00:01:4').get_custom_speed()   2024-03-05 13:09:07,231 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_2) Event handle_l
ink_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112b
d35429d9b07)
kytos $> controller.get_interface_by_id('00:00:00:00:00:00:00:01:4').get_custom_speed()                                                                                                  
Out[1]: 10000000
```

### End-to-End Tests

I'll dispatch an e2e exec with this branch

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 261 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py .....................                  [ 55%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 237 passed, 8 skipped, 9 xfailed, 7 xpassed, 1143 warnings in 12383.73s (3:26:23) =
```