### PR TITLE
fix: `cookie` is no longer a factor of a Flow `match_id`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Fixed
 =====
 - Multipart replies clean up now happens before connection gets established to be safer
 - Set ``interface.speed`` on ``PortStatus`` reason ``OFPPR_ADD`` and ``OFPPR_MODIFY``
-
+- cookie is no longer a factor of a Flow match_id, just so equivalent matches but different cookies don't get different representations
 
 [2023.1.0] - 2023-06-05
 ***********************

--- a/flow.py
+++ b/flow.py
@@ -115,7 +115,6 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
             'table_id': self.table_id,
             'match': self.match.as_dict(),
             'priority': self.priority,
-            'cookie': self.cookie,
         }
         flow_str = json.dumps(flow_match_fields, sort_keys=True)
         md5sum = md5()

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -218,6 +218,10 @@ class TestFlow:
         flow_one = {"match": Match04(**{"in_port": 1, "dl_vlan": 2})}
         flow_two = {"match": Match04(**{"in_port": 1, "dl_vlan": 2})}
         flow_three = {"match": Match04(**{"in_port": 1, "dl_vlan": 3})}
+        flow_four = {"match": Match04(**{"in_port": 1, "dl_vlan": 2}),
+                     "cookie": 0x10}
+        flow_five = {"match": Match04(**{"in_port": 1, "dl_vlan": 2}),
+                     "cookie": 0x20}
 
         assert Flow04(mock_switch, **flow_one).match_id == Flow04(
             mock_switch, **flow_two
@@ -226,9 +230,13 @@ class TestFlow:
             mock_switch, **flow_three
         ).match_id
 
+        # cookie shouldn't matter for match_id
         flow_two["cookie"] = 0x10
-        assert Flow04(mock_switch, **flow_one).match_id != Flow04(
+        assert Flow04(mock_switch, **flow_one).match_id == Flow04(
             mock_switch, **flow_two
+        ).match_id
+        assert Flow04(mock_switch, **flow_four).match_id == Flow04(
+            mock_switch, **flow_five
         ).match_id
 
 


### PR DESCRIPTION
Closes #136 

### Summary

- See updated changelog file
- Migration script will be covered on `flow_manager` https://github.com/kytos-ng/flow_manager/issues/188 

### Local Tests

- Explored with an equivalent case, same match but different cookie, in the DB and in the switch and the cookie got updated accordingly without duplicating a flow document in the DB:

```
{
    "force": false,
    "flows": [
        {
            "priority": 10,
            "cookie": 100,
            "match": {
                "in_port": 1
            },
            "actions": [
                {
                    "action_type": "output",
                    "port": 2
                }
            ]
        },
        {
            "priority": 10,
            "cookie": 101,
            "match": {
                "in_port": 1
            },
            "actions": [
                {
                    "action_type": "output",
                    "port": 2
                }
            ]
        }
    ]
}
```

```
rs0 [direct: primary] napps> db.flows.find({ "flow.cookie": Decimal128("100") })

rs0 [direct: primary] napps> db.flows.find({ "flow.cookie": Decimal128("101") })
[
  {
    _id: '6410aca620aedb1c1aedd6e8af34f796',
    flow: {
      table_id: 0,
      table_group: 'base',
      priority: 10,
      cookie: Decimal128("101"),
      idle_timeout: 0,
      hard_timeout: 0,
      match: { in_port: 1 },
      actions: [ { action_type: 'output', port: 2 } ]
    },
    flow_id: '8620a68ae074b73bab8cdf85bb5c09da',
    id: '6410aca620aedb1c1aedd6e8af34f796',
    inserted_at: ISODate("2024-07-09T13:29:11.351Z"),
    state: 'installed',
    switch: '00:00:00:00:00:00:00:01',
    updated_at: ISODate("2024-07-09T13:29:11.359Z")
  }
]
rs0 [direct: primary] napps> 


❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
[sudo] password for viniarck: 
 cookie=0xab00000000000001, duration=66.492s, table=0, n_packets=132, n_bytes=5544, send_flow_rem priority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=65.609s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=65.607s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0x65, duration=21.135s, table=0, n_packets=1, n_bytes=70, send_flow_rem priority=10,in_port="s1-eth1" actions=output:"s1-eth2"

```

### End-to-End Tests

https://github.com/kytos-ng/kytos-end-to-end-tests/issues/319:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 266 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 242 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12402.27s (3:26:42) =
```
