### PR TITLE
[release 2025.1.1] fix: skip unordered late assembled MULTIPART_REPLY and PORT_STATUS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.1] - 2025-04-26
+***********************
+
+Fixed
+=====
+- Added Interface.state local sequence update counters to skip unordered late assembled PortDesc MULTIPART_REPLY and PORT_STATUS
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Fixed
 =====
-- Added Interface.state local sequence update counters to skip unordered late assembled PortDesc MULTIPART_REPLY and PORT_STATUS
+- Added Interface.state local sequence update counters to skip unordered late assembled PortDesc MULTIPART_REPLY and PORT_STATUS. This feature is enabled by default via ``settings.SKIP_INTF_STATE_LATE_UPDATES = True``.
 
 [2025.1.0] - 2025-04-14
 ***********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2025.1.0",
+  "version": "2025.1.1",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/main.py
+++ b/main.py
@@ -675,13 +675,16 @@ class Main(KytosNApp):
         interface = switch.get_interface_by_port_no(port_no)
         xid_seq_num = self._xid_seq_num[switch.id][int(port_status.header.xid)]
         if (
+            settings.SKIP_INTF_STATE_LATE_UPDATES and
             interface and
             xid_seq_num < self._intf_state_seen_num[switch.id][interface.id]
         ):
+            last_seen = self._intf_state_seen_num[switch.id][interface.id]
             state = state_desc.get(port.state.value, port.state.value)
             log.info(
                 f"Skipping PortStatus {reason} on intf {interface}, "
-                f"state: {state}, xid {xid_seq_num}/0x{xid_seq_num:x}"
+                f"state: {state}, xid {xid_seq_num}/0x{xid_seq_num:x}, "
+                f"last seen xid {last_seen}/0x{last_seen:x}"
             )
             return
 
@@ -752,6 +755,7 @@ class Main(KytosNApp):
             intf = switch.get_interface_by_port_no(port_no)
             xid_seq_num = self._xid_seq_num[switch.id][int(reply.header.xid)]
             if (
+                settings.SKIP_INTF_STATE_LATE_UPDATES and
                 intf and
                 xid_seq_num < self._intf_state_seen_num[switch.id][intf.id]
             ):
@@ -759,9 +763,11 @@ class Main(KytosNApp):
                 state_desc = {v: k for k, v in PortState._enum.items()}
                 # pylint: enable=protected-access
                 state = state_desc.get(port.state.value, port.state.value)
+                last_seen = self._intf_state_seen_num[switch.id][intf.id]
                 log.info(
                     f"Skipping PortDesc on intf {intf}, state: {state}, "
-                    f"xid {xid_seq_num}/0x{xid_seq_num:x}"
+                    f"xid {xid_seq_num}/0x{xid_seq_num:x}, "
+                    f"last seen xid {last_seen}/0x{last_seen:x}"
                 )
                 continue
 

--- a/main.py
+++ b/main.py
@@ -673,18 +673,17 @@ class Main(KytosNApp):
 
         switch = source.switch
         interface = switch.get_interface_by_port_no(port_no)
-        xid_seq_num = self._xid_seq_num[switch.id][int(port_status.header.xid)]
+        xid_val = int(port_status.header.xid)
+        xid_seq_num = self._xid_seq_num[switch.id][xid_val]
         if (
             settings.SKIP_INTF_STATE_LATE_UPDATES and
             interface and
             xid_seq_num < self._intf_state_seen_num[switch.id][interface.id]
         ):
-            last_seen = self._intf_state_seen_num[switch.id][interface.id]
             state = state_desc.get(port.state.value, port.state.value)
             log.info(
                 f"Skipping PortStatus {reason} on intf {interface}, "
-                f"state: {state}, xid {xid_seq_num}/0x{xid_seq_num:x}, "
-                f"last seen xid {last_seen}/0x{last_seen:x}"
+                f"state: {state}, xid {xid_val}/0x{xid_val:x} "
             )
             return
 
@@ -753,7 +752,8 @@ class Main(KytosNApp):
             port_no = port.port_no.value
 
             intf = switch.get_interface_by_port_no(port_no)
-            xid_seq_num = self._xid_seq_num[switch.id][int(reply.header.xid)]
+            xid_val = int(reply.header.xid)
+            xid_seq_num = self._xid_seq_num[switch.id][xid_val]
             if (
                 settings.SKIP_INTF_STATE_LATE_UPDATES and
                 intf and
@@ -763,11 +763,9 @@ class Main(KytosNApp):
                 state_desc = {v: k for k, v in PortState._enum.items()}
                 # pylint: enable=protected-access
                 state = state_desc.get(port.state.value, port.state.value)
-                last_seen = self._intf_state_seen_num[switch.id][intf.id]
                 log.info(
                     f"Skipping PortDesc on intf {intf}, state: {state}, "
-                    f"xid {xid_seq_num}/0x{xid_seq_num:x}, "
-                    f"last seen xid {last_seen}/0x{last_seen:x}"
+                    f"xid {xid_val}/0x{xid_val:x} "
                 )
                 continue
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class Main(KytosNApp):
         self._msg_seq_types = set(
             [Type.OFPT_MULTIPART_REPLY, Type.OFPT_PORT_STATUS]
         )
-        # State last seen local sequence number by switch by intferface id
+        # State last seen local sequence number by switch by interface id
         self._intf_state_seen_num = defaultdict(lambda: defaultdict(int))
         # Local sequence number by switch by xid
         self._xid_seq_num = defaultdict(lambda: defaultdict(int))

--- a/settings.py
+++ b/settings.py
@@ -21,3 +21,7 @@ SEND_ECHO_REQUESTS = True
 
 #: Send Set Config messages right after the OpenFlow handshake
 SEND_SET_CONFIG = True
+
+# Skip late interface state PortDesc and PortStatus updates; Feature flag.
+# This option will be eventually removed and will always be True
+SKIP_INTF_STATE_LATE_UPDATES = True

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -69,6 +69,7 @@ class TestNApp:
         mock_process_multipart_messages.assert_called_with(mock_connection,
                                                            messages)
 
+    # pylint: disable=too-many-locals
     @patch('napps.kytos.of_core.main.Main.process_multipart_messages')
     @patch('napps.kytos.of_core.main.of_slicer')
     @patch('napps.kytos.of_core.main.Main._negotiate')
@@ -76,7 +77,7 @@ class TestNApp:
     async def test_on_raw_in_local_seq_numbers(
         self,
         mock_aemit_message_in,
-        mock_negotiate,
+        _,
         mock_of_slicer,
         mock_process_multipart_messages,
         napp,
@@ -112,7 +113,6 @@ class TestNApp:
                                                        port_status_mock]
         mock_connection.is_new.side_effect = [False, False, False]
         mock_process_multipart_messages.call_count = 0
-        napp.aemit_message_in = AsyncMock()
 
         assert not napp._msg_seq_cnt
         assert not napp._xid_seq_num
@@ -127,7 +127,7 @@ class TestNApp:
         # the port status xid mapped value must be to last counted val
         assert napp._xid_seq_num[mock_switch.id][port_status_xid] == 3
 
-        napp.aemit_message_in.assert_called()
+        mock_aemit_message_in.assert_called()
         mock_process_multipart_messages.assert_called()
 
     @patch('pyof.utils.v0x04.asynchronous.error_msg.ErrorMsg')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -5,7 +5,8 @@ from unittest.mock import (AsyncMock, MagicMock, PropertyMock, create_autospec,
 import pytest
 from napps.kytos.of_core.utils import NegotiationException
 from pyof.foundation.network_types import Ethernet
-from pyof.v0x04.common.port import PortState
+from pyof.v0x04.common.port import PortNo, PortState
+from pyof.v0x04.common.header import Type
 from pyof.v0x04.controller2switch.common import MultipartType
 
 from kytos.core.connection import ConnectionState
@@ -180,10 +181,10 @@ class TestNApp:
 
     @patch('napps.kytos.of_core.main.Main._handle_multipart_table_stats')
     @patch('napps.kytos.of_core.main.Main._handle_multipart_flow_stats')
-    @patch('napps.kytos.of_core.v0x04.utils.handle_port_desc')
+    @patch('napps.kytos.of_core.main.Main._handle_port_desc')
     async def test_handle_multipart_reply(
         self,
-        mock_of_core_v0x04_utils,
+        mock_handle_porst_desc,
         mock_from_of_flow_stats_v0x04,
         mock_from_of_table_stats,
         switch_one,
@@ -206,15 +207,72 @@ class TestNApp:
         ofpmp_port_desc.body = "A"
         ofpmp_port_desc.multipart_type = MultipartType.OFPMP_PORT_DESC
         await napp._handle_multipart_reply(ofpmp_port_desc, switch_one)
-        mock_of_core_v0x04_utils.assert_called_with(
-            napp.controller, switch_one.connection.switch,
-            ofpmp_port_desc.body)
+        mock_handle_porst_desc.assert_called_with(
+            switch_one.connection.switch,
+            ofpmp_port_desc)
 
         ofpmp_desc = MagicMock()
         ofpmp_desc.body = "A"
         ofpmp_desc.multipart_type = MultipartType.OFPMP_DESC
         await napp._handle_multipart_reply(ofpmp_desc, switch_one)
         assert switch_one.update_description.call_count == 1
+
+    async def test_handle_port_desc(self, napp, switch_one):
+        """Test Handle Port Desc."""
+        mock_event_buffer = AsyncMock()
+        napp.controller.buffers.app.aput = mock_event_buffer
+        mock_port = MagicMock()
+        mock_port.port_no.value = PortNo.OFPP_LOCAL.value
+        mock_intf = MagicMock()
+        switch_one.update_or_create_interface.return_value = mock_intf
+        reply = MagicMock()
+        reply.body = [mock_port]
+        await napp._handle_port_desc(switch_one, reply)
+        assert switch_one.update_or_create_interface.call_count == 1
+        mock_event_buffer.assert_called()
+        mock_intf.activate.assert_called()
+        assert napp.controller.buffers.app.aput.call_count == 3
+
+    async def test_handle_port_desc_inactive(self, napp, switch_one):
+        """Test Handle Port Desc inactive interface."""
+        mock_event_buffer = AsyncMock()
+        napp.controller.buffers.app.aput = mock_event_buffer
+        mock_port = MagicMock()
+        mock_port.port_no.value = 1
+        mock_port.state.value = PortState.OFPPS_LINK_DOWN
+        mock_intf = MagicMock()
+        switch_one.update_or_create_interface.return_value = mock_intf
+        reply = MagicMock()
+        reply.body = [mock_port]
+        await napp._handle_port_desc(switch_one, reply)
+        assert switch_one.update_or_create_interface.call_count == 1
+        mock_event_buffer.assert_called()
+        mock_intf.deactivate.assert_called()
+        assert napp.controller.buffers.app.aput.call_count == 3
+
+    async def test_handle_port_desc_seen_state_early_ret(self,
+                                                         napp, switch_one):
+        """Test Handle Port Desc seen state early return ."""
+        switch_one.id = switch_one.dpid
+        mock_event_buffer = AsyncMock()
+        napp.controller.buffers.app.aput = mock_event_buffer
+        mock_port = MagicMock()
+        mock_port.port_no.value = 1
+        mock_port.state.value = PortState.OFPPS_LINK_DOWN
+        mock_intf = MagicMock()
+        mock_intf.id = "1"
+        switch_one.get_interface_by_port_no.return_value = mock_intf
+        switch_one.update_or_create_interface.return_value = mock_intf
+        reply = MagicMock()
+        reply.body = [mock_port]
+        reply.header.xid = 10
+
+        napp._intf_state_seen_num[switch_one.id][mock_intf.id] = 1
+        await napp._handle_port_desc(switch_one, reply)
+        assert not switch_one.update_or_create_interface.call_count
+        mock_event_buffer.assert_not_called()
+        mock_intf.deactivate.assert_not_called()
+        assert not napp.controller.buffers.app.aput.call_count
 
     @patch('napps.kytos.of_core.main.log')
     @patch('napps.kytos.of_core.main.Main._update_switch_flows')
@@ -620,30 +678,6 @@ class TestMain:
             mock_reply, mock_switch, 'flows')
         assert not response
 
-    @patch('napps.kytos.of_core.main.Main.update_port_status')
-    @patch('napps.kytos.of_core.main.Main.update_links')
-    def test_emit_message_in(self, *args):
-        """Test emit_message_in."""
-        (mock_update_links, mock_update_port_status) = args
-
-        mock_port_connection = MagicMock()
-        msg_port_mock = MagicMock()
-        msg_port_mock.header.message_type.name = 'ofpt_port_status'
-        mock_port_connection.side_effect = True
-        self.napp.emit_message_in(mock_port_connection,
-                                  msg_port_mock)
-        mock_update_port_status.assert_called_with(msg_port_mock,
-                                                   mock_port_connection)
-
-        mock_packet_in_connection = MagicMock()
-        msg_packet_in_mock = MagicMock()
-        mock_packet_in_connection.side_effect = True
-        msg_packet_in_mock.header.message_type.name = 'ofpt_packet_in'
-        self.napp.emit_message_in(mock_packet_in_connection,
-                                  msg_packet_in_mock)
-        mock_update_links.assert_called_with(msg_packet_in_mock,
-                                             mock_packet_in_connection)
-
     @patch('napps.kytos.of_core.main.emit_message_out')
     def test_emit_message_out(self, mock_emit_message_out):
         """Test emit message_out."""
@@ -781,3 +815,40 @@ class TestMain:
         mock_port_mod.assert_called()
         mock_buffer_put.assert_called()
         mock_intf.deactivate.assert_called()
+
+    def test_msg_counter_init_values(self, napp) -> None:
+        """Test msg counter init values."""
+        assert napp._msg_seq_types == set(
+            [Type.OFPT_MULTIPART_REPLY, Type.OFPT_PORT_STATUS]
+        )
+        assert not napp._intf_state_seen_num["dpid"]["intf_id"]
+        assert not napp._xid_seq_num["dpid"]["xid"]
+        assert not napp._msg_seq_cnt["dpid"]
+
+    @patch('napps.kytos.of_core.main.Interface')
+    def test_update_port_status_port_state_early_ret(self, mock_interface):
+        """Test update_port_status state early return."""
+        mock_buffer_put = MagicMock()
+        self.napp.controller._buffers.app.put = mock_buffer_put
+        mock_intf = MagicMock()
+        mock_intf.id = "1"
+        mock_interface.return_value = mock_intf
+        mock_port_status = MagicMock()
+        mock_source = MagicMock()
+        switch_mock = MagicMock()
+        switch_mock.id = "1"
+        mock_source.switch = switch_mock
+        switch_mock.get_interface_by_port_no.return_value = mock_intf
+        mock_port = MagicMock()
+        mock_port.state.value = PortState.OFPPS_LIVE
+        speed = 10000000
+        mock_port.curr_speed.value = speed
+
+        self.napp._intf_state_seen_num[switch_mock.id][mock_intf.id] = 1
+
+        mock_port_status.reason.value.side_effect = [0, 1, 2]
+        mock_port_status.reason.enum_ref(0).name = 'OFPPR_ADD'
+        mock_port_status.desc = mock_port
+        self.napp.update_port_status(mock_port_status, mock_source)
+        mock_interface.assert_not_called()
+        assert not mock_intf.activate.call_count == 1

--- a/tests/unit/v0x04/test_utils.py
+++ b/tests/unit/v0x04/test_utils.py
@@ -1,5 +1,5 @@
 """Test v0x04.utils methods."""
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pyof.v0x04.common.port import PortNo, PortState
@@ -7,7 +7,7 @@ from pyof.v0x04.common.port import PortNo, PortState
 from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
                                get_switch_mock)
 from napps.kytos.of_core.v0x04.utils import (handle_features_reply,
-                                             handle_port_desc, say_hello,
+                                             say_hello,
                                              send_desc_request, send_echo,
                                              send_port_request,
                                              send_set_config,
@@ -19,37 +19,6 @@ async def test_say_hello(mock_aemit_message_out, controller, switch_one):
     """Test say_hello."""
     await say_hello(controller, switch_one)
     mock_aemit_message_out.assert_called()
-
-
-async def test_handle_port_desc(controller, switch_one):
-    """Test Handle Port Desc."""
-    mock_event_buffer = AsyncMock()
-    controller.buffers.app.aput = mock_event_buffer
-    mock_port = MagicMock()
-    mock_port.port_no.value = PortNo.OFPP_LOCAL.value
-    mock_intf = MagicMock()
-    switch_one.update_or_create_interface.return_value = mock_intf
-    await handle_port_desc(controller, switch_one, [mock_port])
-    assert switch_one.update_or_create_interface.call_count == 1
-    mock_event_buffer.assert_called()
-    mock_intf.activate.assert_called()
-    assert controller.buffers.app.aput.call_count == 3
-
-
-async def test_handle_port_desc_inactive(controller, switch_one):
-    """Test Handle Port Desc inactive interface."""
-    mock_event_buffer = AsyncMock()
-    controller.buffers.app.aput = mock_event_buffer
-    mock_port = MagicMock()
-    mock_port.port_no.value = 1
-    mock_port.state.value = PortState.OFPPS_LINK_DOWN
-    mock_intf = MagicMock()
-    switch_one.update_or_create_interface.return_value = mock_intf
-    await handle_port_desc(controller, switch_one, [mock_port])
-    assert switch_one.update_or_create_interface.call_count == 1
-    mock_event_buffer.assert_called()
-    mock_intf.deactivate.assert_called()
-    assert controller.buffers.app.aput.call_count == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #145 

### Summary

- See updated changelog file 
- I didn't refactor `update_port_status` to use `switch.update_or_create_interface` since the underlying `threading.Lock` isn't compatible from an asyncio context, and that part isn't the one causing an issue. It was observed with a pcap that indeed there was a 4 ms difference where the port status arrived later, but then our late multipart reply assembled executed last, so now with the local counters it's supposed to be skipped. 
- I added a `settings.SKIP_INTF_STATE_LATE_UPDATES` feature flag for controlled and internal use, eventually this flag will be removed and will always be enabled, it can be handy to have this for now. 
- Release 2025.1.1 is directly targeting `master` since nothing else has landed since the last release

### Local Tests

- Explored links flaps with scripts
- Explored with EVCs too, worked as expected
- I didn't manage to reproduce the same case with OvS, but with unit tests I covered the expected behavior

### End-to-End Tests

- I ran this branch on e2e tests, it's passing (and I'll dispatch another extra exec too), so no regressions, it had reruns but don't seem related to what's being fixed:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 284 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x...................R... [ 22%]
..                                                                       [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 42%]
tests/test_e2e_14_mef_eline.py ......                                    [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .........................R..           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 70%]
tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
tests/test_e2e_31_of_lldp.py ...                                         [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 82%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ..R......                               [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
=========================== rerun test summary info ============================
RERUN tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_200_create_100_untagged_intra_evc
RERUN tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_100_install_delete_flows_in_switch_list
RERUN tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_015_packet_count
= 262 passed, 8 skipped, 7 xfailed, 7 xpassed, 1369 warnings, 3 rerun in 14627.62s (4:03:47) =
```

- Second e2e execution with this branch passed too, no reruns:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 284 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 42%]
tests/test_e2e_14_mef_eline.py ......                                    [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py ...........................            [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 70%]
tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
tests/test_e2e_31_of_lldp.py ...                                         [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 82%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 262 passed, 8 skipped, 7 xfailed, 7 xpassed, 1369 warnings in 14472.29s (4:01:12) =
```