### PR TITLE
Backport: No longer replacing interface object 2024.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.2] - 2025-06-13
+***********************
+
+Changed
+=======
+- Event reason ``OFPPR_ADD`` behaves similar to ``OFPPR_MODIFY`` when interface already exists in switch so the Interface object does not get replaced.
+
 [2024.1.1] - 2025-04-29
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",

--- a/main.py
+++ b/main.py
@@ -687,20 +687,8 @@ class Main(KytosNApp):
             )
             return
 
-        if reason == 'OFPPR_ADD':
+        if reason in ("OFPPR_ADD", "OFPPR_MODIFY"):
             status = 'created'
-            interface = Interface(name=port.name.value,
-                                  address=port.hw_addr.value,
-                                  port_number=port_no,
-                                  switch=source.switch,
-                                  state=port.state.value,
-                                  speed=port.curr_speed.value,
-                                  features=port.curr)
-            source.switch.update_interface(interface)
-            try_to_activate_interface(interface, port)
-
-        elif reason == 'OFPPR_MODIFY':
-            status = 'modified'
             interface = source.switch.get_interface_by_port_no(port_no)
             current_status = None
             if interface:
@@ -720,7 +708,9 @@ class Main(KytosNApp):
                                       features=port.curr)
             source.switch.update_interface(interface)
             try_to_activate_interface(interface, port)
-            self._send_specific_port_mod(port, interface, current_status)
+            if reason == "OFPPR_MODIFY":
+                status = 'modified'
+                self._send_specific_port_mod(port, interface, current_status)
 
         elif reason == 'OFPPR_DELETE':
             status = 'deleted'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -849,11 +849,19 @@ class TestMain:
         speed = 10000000
         mock_port.curr_speed.value = speed
 
+        mock_source.switch.get_interface_by_port_no.return_value = False
         mock_port_status.reason.value.side_effect = [0, 1, 2]
         mock_port_status.reason.enum_ref(0).name = 'OFPPR_ADD'
         mock_port_status.desc = mock_port
         self.napp.update_port_status(mock_port_status, mock_source)
-        mock_interface.assert_called()
+        assert mock_interface.call_count == 1
+        assert mock_intf.activate.call_count == 1
+        assert mock_interface.call_args[1]["speed"] == speed
+
+        # If interface already exists do not create a new Interface object
+        mock_source.switch.get_interface_by_port_no.return_value = MagicMock()
+        self.napp.update_port_status(mock_port_status, mock_source)
+        assert mock_interface.call_count == 1
         assert mock_intf.activate.call_count == 1
         assert mock_interface.call_args[1]["speed"] == speed
 


### PR DESCRIPTION
Closes #151

### Summary

No longer replacing interface object

### Local Tests
Run unit tests and deploy/undeploy topology

### End-to-End Tests
N/A
