### PR TITLE
release: bumped 2025.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.0] - 2026-02-02
+***********************
+
 Changed
 =======
 - Event reason ``OFPPR_ADD`` behaves similar to ``OFPPR_MODIFY`` when interface already exists in switch so the Interface object does not get replaced.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "2025.1.1",
+  "version": "2025.2.0",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/603

### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A (nightly tests passing)
