### PR TITLE
Enhance IPv4/IPv6 parsing/validation by using the built-in lib ipaddress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- Added ``ipaddress`` lib to parser requests for IPv4 and IPv4 on MatchBase,
+allowing validation of IPv6 compressed addresses, IPv4 with /32 masks and
+IPv4 network with host bit set.
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/flow.py
+++ b/flow.py
@@ -7,6 +7,7 @@ inherited in v0x04 modules.
 import json
 from abc import ABC, abstractmethod
 from hashlib import md5
+from ipaddress import AddressValueError, IPv4Network, IPv6Network
 
 from napps.kytos.of_core import v0x04
 from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
@@ -420,6 +421,78 @@ class MatchBase:  # pylint: disable=too-many-instance-attributes
     @abstractmethod
     def as_of_match(self):
         """Return a python-openflow Match."""
+
+    @property
+    def nw_src(self):
+        """The nw_src property."""
+        return self.__dict__["nw_src"]
+
+    @nw_src.setter
+    def nw_src(self, value):
+        """The nw_src setter."""
+        if value is None:
+            self.__dict__["nw_src"] = None
+            return
+        try:
+            self.__dict__["nw_src"] = str(
+                IPv4Network(value)
+            ).removesuffix("/32")
+        except (AddressValueError, ValueError) as exc:
+            raise TypeError(exc) from exc
+
+    @property
+    def nw_dst(self):
+        """The nw_dst property."""
+        return self.__dict__["nw_dst"]
+
+    @nw_dst.setter
+    def nw_dst(self, value):
+        """The nw_dst setter."""
+        if value is None:
+            self.__dict__["nw_dst"] = None
+            return
+        try:
+            self.__dict__["nw_dst"] = str(
+                IPv4Network(value)
+            ).removesuffix("/32")
+        except (AddressValueError, ValueError) as exc:
+            raise TypeError(exc) from exc
+
+    @property
+    def ipv6_src(self):
+        """The ipv6_src property."""
+        return self.__dict__["ipv6_src"]
+
+    @ipv6_src.setter
+    def ipv6_src(self, value):
+        """The ipv6_src setter."""
+        if value is None:
+            self.__dict__["ipv6_src"] = None
+            return
+        try:
+            self.__dict__["ipv6_src"] = str(
+                IPv6Network(value)
+            ).removesuffix("/128")
+        except (AddressValueError, ValueError) as exc:
+            raise TypeError(exc) from exc
+
+    @property
+    def ipv6_dst(self):
+        """The ipv6_dst property."""
+        return self.__dict__["ipv6_dst"]
+
+    @ipv6_dst.setter
+    def ipv6_dst(self, value):
+        """The ipv6_dst setter."""
+        if value is None:
+            self.__dict__["ipv6_dst"] = None
+            return
+        try:
+            self.__dict__["ipv6_dst"] = str(
+                IPv6Network(value)
+            ).removesuffix("/128")
+        except (AddressValueError, ValueError) as exc:
+            raise TypeError(exc) from exc
 
 
 class Stats:

--- a/tests/integration/test_match.py
+++ b/tests/integration/test_match.py
@@ -25,6 +25,7 @@ class TestMatch:
         """Test all match fields from and to dict."""
         match = match_class.from_dict(self.EXPECTED)
         actual = match.as_dict()
+        self.EXPECTED["nw_src"] = "1.2.3.4"
         assert self.EXPECTED == actual
 
     def test_of_match(self):

--- a/tests/unit/test_match.py
+++ b/tests/unit/test_match.py
@@ -92,13 +92,13 @@ class TestMatch:
 
     def test_match04_ipv6(self):
         """Test IPv6 match fields."""
-        VALUE_RESULT_v6 = [
+        value_result_v6 = [
             ("2001:db8:0:100:0:0:0:1/128", "2001:db8:0:100::1"),
             ("2001:db8:0:100:0:0:0:0/64", "2001:db8:0:100::/64"),
             ("2001:0db8:0000:0000:0000:0000:0000:0001", "2001:db8::1"),
             ("::1/128", "::1"),
         ]
-        for value, result in VALUE_RESULT_v6:
+        for value, result in value_result_v6:
             m1 = Match04(ipv6_src=value)
             assert m1.ipv6_src == result
             m2 = Match04(ipv6_dst=value)
@@ -110,13 +110,13 @@ class TestMatch:
 
     def test_match04_ipv4(self):
         """Test IPv4 match fields."""
-        VALUE_RESULT_v4 = [
+        value_result_v4 = [
             ("192.168.0.1/32", "192.168.0.1"),
             ("192.168.0.0/24", "192.168.0.0/24"),
             ("0.0.0.0/0", "0.0.0.0/0"),
             ("255.255.255.255/32", "255.255.255.255"),
         ]
-        for value, result in VALUE_RESULT_v4:
+        for value, result in value_result_v4:
             m1 = Match04(nw_src=value)
             assert m1.nw_src == result
             m2 = Match04(nw_dst=value)

--- a/tests/unit/test_match.py
+++ b/tests/unit/test_match.py
@@ -32,8 +32,8 @@ class TestMatch:
         'sctp_dst': 7,
         'icmpv4_type': 8,
         'icmpv4_code': 9,
-        'ipv6_src': 'abcd:0000:0000:0000:0000:0000:0000:0001/64',
-        'ipv6_dst': 'ef01:0000:0000:0000:0000:0000:0000:0002/48',
+        'ipv6_src': 'abcd:1000:1000:1000:1000:1000:1000:1000/126',
+        'ipv6_dst': 'ef01:0000:0000:0000:0000:0000:0000:0000/48',
         'ipv6_flabel': 27,
         'icmpv6_type': 5,
         'icmpv6_code': 6,
@@ -80,6 +80,7 @@ class TestMatch:
     def test_match_tlv(self):
         """Test OF 1.3 matches"""
         match = Match04.from_dict(self.EXPECTED_OF_13)
+        self.EXPECTED_OF_13["ipv6_dst"] = "ef01::/48"
         assert Match04.from_of_match(match.as_of_match()).as_dict() == \
             self.EXPECTED_OF_13
 
@@ -88,3 +89,39 @@ class TestMatch:
         match_values = {'in_port': 1, 'dl_vlan': 2}
         match_04 = Match04(**match_values)
         assert len(match_04.as_dict()) == len(match_values)
+
+    def test_match04_ipv6(self):
+        """Test IPv6 match fields."""
+        VALUE_RESULT_v6 = [
+            ("2001:db8:0:100:0:0:0:1/128", "2001:db8:0:100::1"),
+            ("2001:db8:0:100:0:0:0:0/64", "2001:db8:0:100::/64"),
+            ("2001:0db8:0000:0000:0000:0000:0000:0001", "2001:db8::1"),
+            ("::1/128", "::1"),
+        ]
+        for value, result in VALUE_RESULT_v6:
+            m1 = Match04(ipv6_src=value)
+            assert m1.ipv6_src == result
+            m2 = Match04(ipv6_dst=value)
+            assert m2.ipv6_dst == result
+        with pytest.raises(TypeError):
+            Match04(ipv6_src="2001:ggg::1")
+        with pytest.raises(TypeError):
+            Match04(ipv6_dst="2001:db8::1/64")
+
+    def test_match04_ipv4(self):
+        """Test IPv4 match fields."""
+        VALUE_RESULT_v4 = [
+            ("192.168.0.1/32", "192.168.0.1"),
+            ("192.168.0.0/24", "192.168.0.0/24"),
+            ("0.0.0.0/0", "0.0.0.0/0"),
+            ("255.255.255.255/32", "255.255.255.255"),
+        ]
+        for value, result in VALUE_RESULT_v4:
+            m1 = Match04(nw_src=value)
+            assert m1.nw_src == result
+            m2 = Match04(nw_dst=value)
+            assert m2.nw_dst == result
+        with pytest.raises(TypeError):
+            Match04(nw_src="192.168.260.1")
+        with pytest.raises(TypeError):
+            Match04(nw_dst="192.168.0.1/24")


### PR DESCRIPTION
Fix https://github.com/kytos-ng/flow_manager/issues/225
Fix https://github.com/kytos-ng/flow_manager/issues/238
Fix https://github.com/kytos-ng/flow_manager/issues/239
Fix https://github.com/kytos-ng/flow_manager/issues/241

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

 Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```