### PR TITLE
Removed redundant kytos event for interfaces.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the of_core NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- The event ``kytos/of_core.switch.interface.created`` is no longer sent when the reply from a switch has type of ``OFPMP_PORT_DESC``. ``topology`` NApp already manages the interfaces afer ``kytos/of_core.switch.port.created`` event.
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Changed
 =======
-- The event ``kytos/of_core.switch.interface.created`` is no longer sent when the reply from a switch has type of ``OFPMP_PORT_DESC``. ``topology`` NApp already manages the interfaces afer ``kytos/of_core.switch.port.created`` event.
+- The event ``kytos/of_core.switch.interface.created`` is no longer sent when the reply from a switch has type of ``OFPMP_PORT_DESC``; it is still sent after ``OFPPR_ADD`` is received. ``topology`` NApp already manages the interfaces afer receiving ``kytos/of_core.switch.interfaces.created`` event.
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/main.py
+++ b/main.py
@@ -772,9 +772,6 @@ class Main(KytosNApp):
             interfaces.append(interface)
             self._intf_state_seen_num[switch.id][interface.id] = xid_seq_num
 
-            event_name = 'kytos/of_core.switch.interface.created'
-            interface_event = KytosEvent(name=event_name,
-                                         content={'interface': interface})
             port_event = KytosEvent(name='kytos/of_core.switch.port.created',
                                     content={
                                         'switch': switch.id,
@@ -786,7 +783,6 @@ class Main(KytosNApp):
                                             }
                                         })
             await self.controller.buffers.app.aput(port_event)
-            await self.controller.buffers.app.aput(interface_event)
         if interfaces:
             event_name = 'kytos/of_core.switch.interfaces.created'
             interface_event = KytosEvent(name=event_name,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -181,7 +181,6 @@ class TestAsync:
         await self.napp._handle_multipart_reply(reply, event_switch)
 
         ex_switch = 'kytos/of_core.switch.port.created'
-        ex_interface = 'kytos/of_core.switch.interface.created'
         ex_interfaces = 'kytos/of_core.switch.interfaces.created'
         ex_dpid = '00:00:00:00:00:00:00:02'
         ex_port = 7
@@ -189,13 +188,9 @@ class TestAsync:
         for _ in range(0, 2):
             for i in range(0, 2):
                 of_event_01 = await self.napp.controller.buffers.app.aget()
-                of_event_02 = await self.napp.controller.buffers.app.aget()
                 assert of_event_01.name == ex_switch
                 assert of_event_01.content['switch'] == ex_dpid
                 assert of_event_01.content['port'] == ex_port - i
-                assert of_event_02.name == ex_interface
-                assert getattr(of_event_02.content['interface'],
-                               'port_number') == ex_port - i
 
             of_event_01 = await self.napp.controller.buffers.app.aget()
             assert of_event_01.name == ex_interfaces

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -292,7 +292,7 @@ class TestNApp:
         assert switch_one.update_or_create_interface.call_count == 1
         mock_event_buffer.assert_called()
         mock_intf.activate.assert_called()
-        assert napp.controller.buffers.app.aput.call_count == 3
+        assert napp.controller.buffers.app.aput.call_count == 2
 
     async def test_handle_port_desc_inactive(self, napp, switch_one):
         """Test Handle Port Desc inactive interface."""
@@ -309,7 +309,7 @@ class TestNApp:
         assert switch_one.update_or_create_interface.call_count == 1
         mock_event_buffer.assert_called()
         mock_intf.deactivate.assert_called()
-        assert napp.controller.buffers.app.aput.call_count == 3
+        assert napp.controller.buffers.app.aput.call_count == 2
 
     @patch('napps.kytos.of_core.main.log')
     async def test_handle_port_desc_seen_state_early_ret(self, mock_log,


### PR DESCRIPTION
Closes #160 

### Summary

- Removed `kytos/of_core.switch.interface.created` when later `kytos/of_core.switch.interfaces.created` is sent.

### Local Tests
Removed and added interfaces.

### End-to-End Tests
Results [here](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/424).
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
```
