### PR TITLE
Consider sending_features as a valid state for waiting features reply

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Changed
 - Added ``ipaddress`` lib to parser requests for IPv4 and IPv4 on MatchBase,
 allowing validation of IPv6 compressed addresses, IPv4 with /32 masks and
 IPv4 network with host bit set.
+- Adding ``sending_features`` as a valid state for waiting features during
+OF Handshake phase.
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/main.py
+++ b/main.py
@@ -368,7 +368,10 @@ class Main(KytosNApp):
                 ofp_msg_type_str = message.header.message_type.name.lower()
                 waiting_features_reply = (
                     ofp_msg_type_str == 'ofpt_features_reply'
-                    and connection.protocol.state == 'waiting_features_reply')
+                    and connection.protocol.state in (
+                        'waiting_features_reply', 'sending_features'
+                    )
+                )
 
                 if connection.is_during_setup() and not waiting_features_reply:
                     unprocessed_packets.append(packet)


### PR DESCRIPTION
Closes #163 

Heads-up: this PR should sit on top of PR https://github.com/kytos-ng/of_core/pull/159

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

### End-to-End Tests

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```