### PR TITLE
Refactor: `kytos/of_core.switch.interfaces.created` now also included dpid and is always published 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Changed
 =======
+- Port description handler now publishes ``kytos/of_core.switch.interface.created`` even if interfaces are empty, this is to facilitate for ``of_lldp`` to get an event when interfaces have been created. This event also now includes ``dpid`` too in its body
 - The event ``kytos/of_core.switch.interface.created`` is no longer sent when the reply from a switch has type of ``OFPMP_PORT_DESC``; it is still sent after ``OFPPR_ADD`` is received. ``topology`` NApp already manages the interfaces afer receiving ``kytos/of_core.switch.interfaces.created`` event.
 - If a duplicated DPID is detected when handling features reply it'll log an error and return
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to the of_core NApp will be documented in this file.
 
 Changed
 =======
-- Port description handler now publishes ``kytos/of_core.switch.interface.created`` even if interfaces are empty, this is to facilitate for ``of_lldp`` to get an event when interfaces have been created. This event also now includes ``dpid`` too in its body
+- Port description handler now publishes ``kytos/of_core.switch.interfaces.created`` even if interfaces are empty, this is to facilitate for ``of_lldp`` to get an event when interfaces have been created. This event also now includes ``dpid`` too in its body
 - The event ``kytos/of_core.switch.interface.created`` is no longer sent when the reply from a switch has type of ``OFPMP_PORT_DESC``; it is still sent after ``OFPPR_ADD`` is received. ``topology`` NApp already manages the interfaces afer receiving ``kytos/of_core.switch.interfaces.created`` event.
 - If a duplicated DPID is detected when handling features reply it'll log an error and return
 

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,7 @@ Content:
 
    {
     'interfaces': [<interface>] # Instance of Interface class
+    'dpid': <switch.id>
    }
 
 kytos/of_core.flow_stats.received

--- a/main.py
+++ b/main.py
@@ -789,11 +789,12 @@ class Main(KytosNApp):
                                             }
                                         })
             await self.controller.buffers.app.aput(port_event)
-        if interfaces:
-            event_name = 'kytos/of_core.switch.interfaces.created'
-            interface_event = KytosEvent(name=event_name,
-                                         content={'interfaces': interfaces})
-            await self.controller.buffers.app.aput(interface_event)
+
+        event_name = 'kytos/of_core.switch.interfaces.created'
+        interface_event = KytosEvent(name=event_name,
+                                     content={'interfaces': interfaces,
+                                              'dpid': switch.id})
+        await self.controller.buffers.app.aput(interface_event)
 
 
 def _get_version_from_bitmask(message_versions):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -339,8 +339,7 @@ class TestNApp:
         mock_log.info.assert_called()
 
     @patch('napps.kytos.of_core.main.log')
-    async def test_handle_port_desc_empty_intfs(self, mock_log, napp,
-                                                switch_one):
+    async def test_handle_port_desc_empty_intfs(self, napp, switch_one):
         """Test Handle Port Desc empty intfs."""
         switch_one.id = switch_one.dpid
         mock_event_buffer = AsyncMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -333,10 +333,31 @@ class TestNApp:
         napp._intf_state_seen_num[switch_one.id][mock_intf.id] = 1
         await napp._handle_port_desc(switch_one, reply)
         assert not switch_one.update_or_create_interface.call_count
-        mock_event_buffer.assert_not_called()
+        mock_event_buffer.assert_called()
         mock_intf.deactivate.assert_not_called()
-        assert not napp.controller.buffers.app.aput.call_count
+        assert napp.controller.buffers.app.aput.call_count == 1
         mock_log.info.assert_called()
+
+    @patch('napps.kytos.of_core.main.log')
+    async def test_handle_port_desc_empty_intfs(self, mock_log, napp,
+                                                switch_one):
+        """Test Handle Port Desc empty intfs."""
+        switch_one.id = switch_one.dpid
+        mock_event_buffer = AsyncMock()
+        napp.controller.buffers.app.aput = mock_event_buffer
+        reply = MagicMock()
+        reply.body = []
+        reply.header.xid = 10
+
+        await napp._handle_port_desc(switch_one, reply)
+        assert not switch_one.update_or_create_interface.call_count
+        mock_event_buffer.assert_called()
+        assert napp.controller.buffers.app.aput.call_count == 1
+        args = napp.controller.buffers.app.aput.call_args
+        ev = args[0][0]
+        assert ev.name.endswith("interfaces.created")
+        assert ev.content["interfaces"] == []
+        assert "dpid" in ev.content
 
     @patch('napps.kytos.of_core.main.log')
     @patch('napps.kytos.of_core.main.Main._update_switch_flows')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -338,9 +338,7 @@ class TestNApp:
         assert napp.controller.buffers.app.aput.call_count == 1
         mock_log.info.assert_called()
 
-    @patch('napps.kytos.of_core.main.log')
-    async def test_handle_port_desc_empty_intfs(self, mock_log,
-                                                napp, switch_one):
+    async def test_handle_port_desc_empty_intfs(self, napp, switch_one):
         """Test Handle Port Desc empty intfs."""
         switch_one.id = switch_one.dpid
         mock_event_buffer = AsyncMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -339,7 +339,8 @@ class TestNApp:
         mock_log.info.assert_called()
 
     @patch('napps.kytos.of_core.main.log')
-    async def test_handle_port_desc_empty_intfs(self, napp, switch_one):
+    async def test_handle_port_desc_empty_intfs(self, mock_log,
+                                                napp, switch_one):
         """Test Handle Port Desc empty intfs."""
         switch_one.id = switch_one.dpid
         mock_event_buffer = AsyncMock()


### PR DESCRIPTION
Related to https://github.com/kytos-ng/of_lldp/pull/131

### Summary

See updated changelog file 

### Local Tests

See https://github.com/kytos-ng/of_lldp/pull/131

### End-to-End Tests

See https://github.com/kytos-ng/of_lldp/pull/131