### PR TITLE
fix: xid seq nums can grow unbounded (mem leak related)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Changed
 - If a duplicated DPID is detected when handling features reply it'll log an error and return
 - Adding ``sending_features`` as a valid state for waiting features during OF Handshake phase.
 
+Fixed
+=====
+
+- Popped xid seq nums after use to avoid unbounded mem growth
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -207,6 +207,8 @@ class Main(KytosNApp):
             await self._handle_port_desc(switch, reply)
         elif reply.multipart_type == MultipartType.OFPMP_DESC:
             switch.update_description(reply.body)
+        if reply.flags.value % 2 == 0:
+            self._xid_seq_num[switch.id].pop(int(reply.header.xid), None)
 
     async def _handle_multipart_flow_stats(self, reply, switch):
         """Update switch flows after all replies are received.
@@ -577,10 +579,18 @@ class Main(KytosNApp):
         self._xid_seq_num.pop(switch.id, None)
         self._msg_seq_cnt.pop(switch.id, None)
 
+    @alisten_to("kytos/core.openflow.connection.lost")
+    async def on_openflow_connection_lost(self, event):
+        """On openflow connection lost clean up the per-connection lock."""
+        connection = event.content["source"]
+        self._connection_lock.pop(connection.id, None)
+
     @alisten_to("kytos/core.openflow.connection.error")
     async def on_openflow_connection_error(self, event):
         """On openflow connection error try to pop multipart replies."""
-        switch = event.content["destination"].switch
+        connection = event.content["destination"]
+        self._connection_lock.pop(connection.id, None)
+        switch = connection.switch
         if not switch:
             return
         self.pop_multipart_replies(switch)
@@ -684,6 +694,7 @@ class Main(KytosNApp):
         interface = switch.get_interface_by_port_no(port_no)
         xid_val = int(port_status.header.xid)
         xid_seq_num = self._xid_seq_num[switch.id][xid_val]
+        self._xid_seq_num[switch.id].pop(xid_val, None)
         if (
             settings.SKIP_INTF_STATE_LATE_UPDATES and
             interface and

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -533,6 +533,80 @@ class TestNApp:
         assert napp.pop_multipart_replies.call_count == 0
         assert napp.pop_seq_msg_counters.call_count == 0
 
+    def test_update_port_status_pops_xid_seq_num(self, napp) -> None:
+        """update_port_status should drop the consumed xid seq num so
+        _xid_seq_num does not grow unbounded per switch."""
+        switch = MagicMock(id="00:00:00:00:00:00:00:01")
+        intf = MagicMock(id="00:00:00:00:00:00:00:01:1")
+        switch.get_interface_by_port_no.return_value = intf
+        source = MagicMock(switch=switch)
+        port_status = MagicMock()
+        port_status.header.xid = 0xABE
+        xid_val = int(port_status.header.xid)
+        napp._xid_seq_num[switch.id][xid_val] = 1
+        # Make it a late update so the method returns early after popping.
+        napp._intf_state_seen_num[switch.id][intf.id] = 5
+        napp.update_port_status(port_status, source)
+        assert xid_val not in napp._xid_seq_num[switch.id]
+
+    async def test_handle_multipart_reply_pops_xid_seq_num(self, napp) -> None:
+        """_handle_multipart_reply should drop the consumed xid seq num so
+        _xid_seq_num does not grow one entry per stats cycle."""
+        switch = MagicMock(id="00:00:00:00:00:00:00:01")
+        reply = MagicMock()
+        reply.multipart_type = MultipartType.OFPMP_DESC
+        reply.header.xid = 0xABC
+        reply.flags.value = 0  # no MORE flag
+        xid_val = int(reply.header.xid)
+        napp._xid_seq_num[switch.id][xid_val] = 3
+        await napp._handle_multipart_reply(reply, switch)
+        assert xid_val not in napp._xid_seq_num[switch.id]
+
+    async def test_handle_multipart_reply_retains_xid_seq_num_on_more(
+        self, napp
+    ) -> None:
+        """_handle_multipart_reply must NOT pop the xid while MORE flag is set.
+
+        PORT_DESC can span multiple replies sharing the same xid.  Popping
+        early would cause _handle_port_desc to read xid_seq_num=0 for
+        subsequent replies and incorrectly skip late-update filtering.
+        """
+        switch = MagicMock(id="00:00:00:00:00:00:00:01")
+        reply = MagicMock()
+        reply.multipart_type = MultipartType.OFPMP_DESC
+        reply.header.xid = 0xABC
+        reply.flags.value = 1  # MORE flag set — simulates intermediate reply
+        xid_val = int(reply.header.xid)
+        napp._xid_seq_num[switch.id][xid_val] = 7
+        await napp._handle_multipart_reply(reply, switch)
+        assert xid_val in napp._xid_seq_num[switch.id]
+
+    async def test_on_openflow_connection_error_pops_connection_lock(
+        self, napp
+    ) -> None:
+        """on_openflow_connection_error should drop the per-connection lock so
+        _connection_lock does not grow one Lock per reconnect."""
+        event = MagicMock()
+        connection = event.content["destination"]
+        connection.id = ("192.0.2.1", 54321)
+        connection.switch = MagicMock(id="00:00:00:00:00:00:00:01")
+        _ = napp._connection_lock[connection.id]
+        assert connection.id in napp._connection_lock
+        await napp.on_openflow_connection_error(event)
+        assert connection.id not in napp._connection_lock
+
+    async def test_on_openflow_connection_lost_pops_connection_lock(
+        self, napp
+    ) -> None:
+        """on_openflow_connection_lost should drop the per-connection lock."""
+        event = MagicMock()
+        connection = event.content["source"]
+        connection.id = ("192.0.2.1", 54321)
+        _ = napp._connection_lock[connection.id]
+        assert connection.id in napp._connection_lock
+        await napp.on_openflow_connection_lost(event)
+        assert connection.id not in napp._connection_lock
+
 
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=import-outside-toplevel

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -14,7 +14,7 @@ from kytos.core.exceptions import KytosDuplicatedSwitch
 from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
                                get_kytos_event_mock, get_switch_mock)
 
-# pylint: disable=protected-access, invalid-name
+# pylint: disable=protected-access, invalid-name, too-many-lines
 
 
 class TestNApp:


### PR DESCRIPTION
Closes #167 

### Summary

- See updated changelog file
- The leak is proportional to the number of multi part replies and port status in a topology

### Local Tests

In a ring topology with 3 switches with hundreds of flows, `of_core._xid_seq_num` was growing roughly at 1k xid entries every 15 mins, overtime this will add up significantly (not as much as [the recent fix on kytos_stats](https://github.com/kytos-ng/kytos_stats/issues/31) but still significant), the bigger the topology the higher the rate:

```
of_core = controller.napps[('kytos', 'of_core')]

kytos $> sum(len(v) for v in of_core._xid_seq_num.values())
Out[52]: 927

kytos $> sum(len(v) for v in of_core._xid_seq_num.values())
Out[53]: 930

kytos $> sum(len(v) for v in of_core._xid_seq_num.values())
Out[54]: 954

kytos $> sum(len(v) for v in of_core._xid_seq_num.values())
Out[55]: 954
```

With this branch:

```
kytos $> of_core._msg_seq_cnt
Out[29]: 
defaultdict(int,
            {'00:00:00:00:00:00:00:01': 62,
             '00:00:00:00:00:00:00:03': 47,
             '00:00:00:00:00:00:00:02': 47})

kytos $> 

kytos $> sum(len(v) for v in of_core._xid_seq_num.values())
Out[30]: 0

kytos $> sum(len(v) for v in of_core._xid_seq_num.values())
Out[31]: 0

```

### End-to-End Tests

With this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 309 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx..                                 [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .......                                   [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ......                                      [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
=============================== warnings summary ===============================
tests/test_e2e_01_kytos_startup.py: 17 warnings
------------------------------- start/stop times -------------------------------
= 297 passed, 9 skipped, 2 xfailed, 1 xpassed, 1394 warnings in 15914.09s (4:25:14) =
````